### PR TITLE
Add missing Stats.StoreStats() API-method

### DIFF
--- a/Facepunch.Steamworks/Client/Stats.cs
+++ b/Facepunch.Steamworks/Client/Stats.cs
@@ -14,6 +14,11 @@ namespace Facepunch.Steamworks
             client = c;
         }
 
+		public bool StoreStats()
+		{
+			return client.native.userstats.StoreStats();
+		}
+
         public void UpdateStats()
         {
             client.native.userstats.RequestCurrentStats();


### PR DESCRIPTION
I ran into the exact issue described in #19 and dug a little into the Steamworks API.

It appears that Steamworks does not commit stat changes such as unlocked achievements to Steam until it is explicitly told to do so. (This happens implicitly during cleanup upon shutdown)

This pull request adds the missing Client.Stats.StoreStats() API-method that one needs to call to commit stat changes from Steamworks to Steam. Calling this method right after Client.Achievements.Trigger(...) will cause Steam overlay to show the appropriate achievement-unlocked toast immediately.