### PR TITLE
Added missing SetStat Methods

### DIFF
--- a/Facepunch.Steamworks/Client/Stats.cs
+++ b/Facepunch.Steamworks/Client/Stats.cs
@@ -59,6 +59,16 @@ namespace Facepunch.Steamworks
             return data;
         }
 
+        public bool SetInt(string name, int data)
+        {
+            return client.native.userstats.SetStat(name, data);
+        }
+
+        public bool SetFloat(string name, float data)
+        {
+            return client.native.userstats.SetStat0(name, data);
+        }
+
         public void Dispose()
         {
             client = null;

--- a/Facepunch.Steamworks/Client/Stats.cs
+++ b/Facepunch.Steamworks/Client/Stats.cs
@@ -65,7 +65,7 @@ namespace Facepunch.Steamworks
         /// </summary>
         public bool SetInt( string name, int data )
         {
-            return client.native.userstats.SetStat(name, data);
+            return client.native.userstats.SetStat( name, data );
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Facepunch.Steamworks
         /// </summary>
         public bool SetFloat( string name, float data )
         {
-            return client.native.userstats.SetStat0(name, data);
+            return client.native.userstats.SetStat0( name, data );
         }
 
         /// <summary>

--- a/Facepunch.Steamworks/Client/Stats.cs
+++ b/Facepunch.Steamworks/Client/Stats.cs
@@ -67,6 +67,7 @@ namespace Facepunch.Steamworks
         {
             return client.native.userstats.SetStat(name, data);
         }
+
         /// <summary>
         /// Sets client stat float
         /// You should call StoreStats() manually after this

--- a/Facepunch.Steamworks/Client/Stats.cs
+++ b/Facepunch.Steamworks/Client/Stats.cs
@@ -59,14 +59,49 @@ namespace Facepunch.Steamworks
             return data;
         }
 
-        public bool SetInt(string name, int data)
+        /// <summary>
+        /// Sets client stat integer
+        /// You should call StoreStats() manually after this
+        /// </summary>
+        public bool SetInt( string name, int data )
         {
             return client.native.userstats.SetStat(name, data);
         }
-
-        public bool SetFloat(string name, float data)
+        /// <summary>
+        /// Sets client stat float
+        /// You should call StoreStats() manually after this
+        /// </summary>
+        public bool SetFloat( string name, float data )
         {
             return client.native.userstats.SetStat0(name, data);
+        }
+
+        /// <summary>
+        /// Sets client stat integer and store it
+        /// Retruns true if stat was successfully stored
+        /// </summary>
+        public bool SetIntAndStore( string name, int data )
+        {
+            bool saveInt = client.native.userstats.SetStat( name, data );
+            if ( saveInt )
+            {
+                return client.native.userstats.StoreStats();
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Sets client stat float and store it
+        /// Retruns true if stat was successfully stored
+        /// </summary>
+        public bool SetFloatAndStore( string name, float data )
+        {
+            bool saveFloat = client.native.userstats.SetStat0( name, data );
+            if ( saveFloat )
+            {
+                return client.native.userstats.StoreStats();
+            }
+            return false;
         }
 
         public void Dispose()


### PR DESCRIPTION
Added SetInt( name, data ) and SetFloat( name, data ) methods needed to set client stats.
After those we need to call StoreStats manually, so they are good when we set multiple stats.
For instance:
Stats.SetInt( "value_one", 1 );
Stats.SetFloat( "value_two_two", 2f );
Stats.SetInt( "value_three_three_three", 3 );
Stats.StoreStats();

Accordingly to https://github.com/Facepunch/Facepunch.Steamworks/pull/21#issuecomment-307038698
I Added
SetIntAndStore( name, data ) and SetFloatAndStore( name, data ) which call StoreStats after set.
Good for changing only single stat at a time.