### PR TITLE
Updated  Workshop.onDownloadResult to compare downloaded item's application to current application

### DIFF
--- a/Facepunch.Steamworks/Interfaces/Workshop.cs
+++ b/Facepunch.Steamworks/Interfaces/Workshop.cs
@@ -73,7 +73,7 @@ namespace Facepunch.Steamworks
 
         private void onDownloadResult( SteamNative.DownloadItemResult_t obj, bool failed )
         {
-            if ( OnFileDownloaded != null )
+            if ( OnFileDownloaded != null && obj.AppID == Client.Instance.AppId )
                 OnFileDownloaded( obj.PublishedFileId, (Callbacks.Result) obj.Result );
         }
 


### PR DESCRIPTION
updated Workshop.onDownloadResult method to ensure that the item's app ID matches the client app id, as described in the DownloadItemResult_t Steamworks documentation.

`The ISteamUGC::DownloadItemResult_t callback struct contains the application ID (m_unAppID) associated with the workshop item. It should be compared against the running application ID as the handler will be called for all item downloads regardless of the running application.`
from [Steamworks Documentation](https://partner.steamgames.com/doc/features/workshop/implementation)