### PR TITLE
Made changes surrounding OnItemInstalled and OnFileDownloaded events in Workshop.cs

### DIFF
--- a/Facepunch.Steamworks/Interfaces/Workshop.cs
+++ b/Facepunch.Steamworks/Interfaces/Workshop.cs
@@ -29,8 +29,7 @@ namespace Facepunch.Steamworks
 
         /// <summary>
         /// Called when an item has been downloaded. This could have been
-        /// because of a call to Download or because of a subscription triggered
-        /// via the browser/app.
+        /// because of a call to Download.
         /// </summary>
         public event Action<ulong, Callbacks.Result> OnFileDownloaded;
 

--- a/Facepunch.Steamworks/Interfaces/Workshop.cs
+++ b/Facepunch.Steamworks/Interfaces/Workshop.cs
@@ -67,7 +67,7 @@ namespace Facepunch.Steamworks
 
         private void onItemInstalled( SteamNative.ItemInstalled_t obj, bool failed )
         {
-            if ( OnItemInstalled != null )
+            if ( OnItemInstalled != null && obj.AppID == Client.Instance.AppId )
                 OnItemInstalled( obj.PublishedFileId );
         }
 

--- a/Facepunch.Steamworks/Interfaces/Workshop.cs
+++ b/Facepunch.Steamworks/Interfaces/Workshop.cs
@@ -39,7 +39,7 @@ namespace Facepunch.Steamworks
         /// because of a call to Download or because of a subscription triggered
         /// via the browser/app.
         /// </summary>
-        internal event Action<ulong> OnItemInstalled;
+        public event Action<ulong> OnItemInstalled;
 
         internal Workshop( BaseSteamworks steamworks, SteamNative.SteamUGC ugc, SteamNative.SteamRemoteStorage remoteStorage )
         {


### PR DESCRIPTION
Similar to my last pull request, I realized that OnItemInstalled should be comparing the AppId of the downloaded file to that of the current application, so I added that comparison.

I also made the OnItemInstalled event public, so I could use it to determine when a workshop item has been subscribed to while playing the game, using the in-game overlay. It seems that the OnFileDownloaded event is not triggered when a workshop item is subscribed to, so I updated the summary accordingly.