### PR TITLE
Fixes bug where Lobby Owner was unable to be set

### DIFF
--- a/Facepunch.Steamworks.Test/Facepunch.Steamworks.Test.csproj
+++ b/Facepunch.Steamworks.Test/Facepunch.Steamworks.Test.csproj
@@ -94,6 +94,7 @@
   <ItemGroup>
     <Compile Include="Client\Achievements.cs" />
     <Compile Include="Client\Client.cs" />
+    <Compile Include="Client\Lobby.cs" />
     <Compile Include="Client\RichPresence.cs" />
     <Compile Include="Client\Leaderboard.cs" />
     <Compile Include="Client\App.cs" />

--- a/Facepunch.Steamworks/Client/Lobby.cs
+++ b/Facepunch.Steamworks/Client/Lobby.cs
@@ -421,7 +421,7 @@ namespace Facepunch.Steamworks
                 }
                 return _owner;
             }
-            private set
+            set
             {
                 if (_owner == value) return;
                 if (client.native.matchmaking.SetLobbyOwner(CurrentLobby, value)) { _owner = value; }


### PR DESCRIPTION
Accidentally left Owner property as private set. It is fine to be public, because if a non-owner tries to set the prop it won't do anything.