### PR TITLE
Added AddScreenshotToLibrary

### DIFF
--- a/Facepunch.Steamworks/Client/Screenshots.cs
+++ b/Facepunch.Steamworks/Client/Screenshots.cs
@@ -66,5 +66,15 @@ namespace Facepunch.Steamworks
                 client.native.screenshots.WriteScreenshot( (IntPtr) ptr, (uint) rgbData.Length, width, height );
             }
         }
+        
+        public unsafe void AddScreenshotToLibrary( string filename, string thumbnailFilename, int width, int height) 
+        {
+            client.native.screenshots.AddScreenshotToLibrary(filename, thumbnailFilename, width, height);
+        }
+
+        public unsafe void AddScreenshotToLibrary( string filename, int width, int height) 
+        {
+            client.native.screenshots.AddScreenshotToLibrary(filename, null, width, height);
+        }
     }
 }


### PR DESCRIPTION
Added AddScreenshotToLibrary(filename, thumbnailFilename, width, height); 
and AddScreenshotToLibrary(filename, width, height); 

We use Application.TakeScreenshot(path, superSize) in some of our in-game tools (like the camera) to allow for higher-res screenshots, 
and this feels like a much faster way of doing it then loading the PNG back into a texture2D, converting it into a correct format, and using Write to get it in Steam.