### PR TITLE
added client.Overlay.Enabled property (tells you whether the overlay …

### DIFF
--- a/Facepunch.Steamworks/Client/Overlay.cs
+++ b/Facepunch.Steamworks/Client/Overlay.cs
@@ -25,6 +25,11 @@ namespace Facepunch.Steamworks
     {
         internal Client client;
 
+        public bool Enabled
+        {
+            get { return client.native.utils.IsOverlayEnabled(); }
+        }
+
         public void OpenUserPage( string name, ulong steamid ) { client.native.friends.ActivateGameOverlayToUser( name, steamid ); }
 
         public void OpenProfile( ulong steamid ) { OpenUserPage( "steamid", steamid ); }


### PR DESCRIPTION
…is actually available)
needed this because if you launch unity games outside of steam client, the steam login will succeed but the overlay is actually not available