### PR TITLE
Only add lobby distance filter if user does

### DIFF
--- a/Facepunch.Steamworks/Client/LobbyList.cs
+++ b/Facepunch.Steamworks/Client/LobbyList.cs
@@ -30,20 +30,23 @@ namespace Facepunch.Steamworks
         /// Refresh the List of Lobbies. If no filter is passed in, a default one is created that filters based on AppId ("appid").
         /// </summary>
         /// <param name="filter"></param>
-        public void Refresh ( Filter filter = null)
+        public void Refresh(Filter filter = null)
         {
             //init out values
             Lobbies.Clear();
             requests.Clear();
             Finished = false;
+            
+            if (filter != null)
+            {
+                client.native.matchmaking.AddRequestLobbyListDistanceFilter((SteamNative.LobbyDistanceFilter)filter.DistanceFilter);
+            }
 
             if (filter == null)
             {
                 filter = new Filter();
                 filter.StringFilters.Add("appid", client.AppId.ToString());
             }
-
-            client.native.matchmaking.AddRequestLobbyListDistanceFilter((SteamNative.LobbyDistanceFilter)filter.DistanceFilter);
 
             if (filter.SlotsAvailable != null)
             {


### PR DESCRIPTION
Currently the distance filter defaults to close when no filter is
provided. This is unexpected. If the user did not give a filter no
filter should be applied. This change checks for a filter before the
dummy appid filter is created, and only adds the distance filter if a
filter was provided.