### PR TITLE
Correctly handle lobby refresh with null filter

### DIFF
--- a/Facepunch.Steamworks/Client/LobbyList.cs
+++ b/Facepunch.Steamworks/Client/LobbyList.cs
@@ -41,6 +41,8 @@ namespace Facepunch.Steamworks
             {
                 filter = new Filter();
                 filter.StringFilters.Add("appid", client.AppId.ToString());
+                client.native.matchmaking.RequestLobbyList(OnLobbyList);
+                return;
             }
 
             client.native.matchmaking.AddRequestLobbyListDistanceFilter((SteamNative.LobbyDistanceFilter)filter.DistanceFilter);


### PR DESCRIPTION
Currently if a null filter is given, more filters are added to the call
than expected. This change makes a lobby request after the appid filter
is added and returns immediately resolving the issue.