### PR TITLE
Resolved #174  - removed redundant check in InitClient to allow wrapper initialization in offline mode

### DIFF
--- a/Facepunch.Steamworks/Client.cs
+++ b/Facepunch.Steamworks/Client.cs
@@ -254,6 +254,13 @@ namespace Facepunch.Steamworks
             return board;
         }
 
+        /// <summary>
+        /// Checks if the current user's Steam client is connected and logged on to the Steam servers.
+        /// If it's not then no real-time services provided by the Steamworks API will be enabled. 
+        /// The Steam client will automatically be trying to recreate the connection as often as possible.
+        /// All of the API calls that rely on this will check internally.
+        /// </summary>
+        public bool IsLoggedOn => native.user.BLoggedOn();
 
         /// <summary>
         /// True if we're subscribed/authorised to be running this app

--- a/Facepunch.Steamworks/Interop/Native.cs
+++ b/Facepunch.Steamworks/Interop/Native.cs
@@ -60,14 +60,6 @@ namespace Facepunch.Steamworks.Interop
                 return false;
             }
 
-            // Ensure that the user has logged into Steam. This will always return true if the game is launched
-            // from Steam, but if Steam is at the login prompt when you run your game it will return false.
-            if ( !user.BLoggedOn() )
-            {
-                Console.Error.WriteLine( "InitClient: Not Logged On" );
-                return false;
-            }
-
             return true;
         }
 


### PR DESCRIPTION
Exposed LoggedOn property to manually check the client if it's connected and logged on to the (online) Steam servers.

Pulling as to resolve  https://github.com/Facepunch/Facepunch.Steamworks/issues/174

I have used the change in a functioning project, and run provided tests (though some failed due to how differently my project is configured compared to the Rust). Please merge as to resolve future problems with offline mode.

