### PR TITLE
Fixed Windows x86 build crash on startup

### DIFF
--- a/Facepunch.Steamworks/Config.cs
+++ b/Facepunch.Steamworks/Config.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Facepunch.Steamworks
 {
@@ -18,6 +15,11 @@ namespace Facepunch.Steamworks
             //
             if ( platform == "WindowsEditor" || platform == "WindowsPlayer" )
             {
+                //
+                // 32bit windows unity uses a stdcall
+                //
+                if (IntPtr.Size == 4) UseThisCall = false;
+
                 ForcePlatform( OperatingSystem.Windows, IntPtr.Size == 4 ? Architecture.x86 : Architecture.x64 );                
             }
 
@@ -30,8 +32,6 @@ namespace Facepunch.Steamworks
             {
                 ForcePlatform( OperatingSystem.Linux, IntPtr.Size == 4 ? Architecture.x86 : Architecture.x64 );
             }
-
-            UseThisCall = true;
 
             Console.WriteLine( "Facepunch.Steamworks Unity: " + platform );
             Console.WriteLine( "Facepunch.Steamworks Os: " + SteamNative.Platform.Os );
@@ -47,7 +47,7 @@ namespace Facepunch.Steamworks
         /// for releasing his shit open source under the MIT license so we can all learn and iterate.
         /// 
         /// </summary>
-        public static bool UseThisCall { get; set; } = SteamNative.Platform.Os == OperatingSystem.Windows;
+        public static bool UseThisCall { get; set; } = true;
 
 
         /// <summary>


### PR DESCRIPTION
x86-x64 works fine, but x86 crash on startup.

Version 0.7 has lines:
//
// 32bit windows unity uses a stdcall
//
if ( IntPtr.Size == 4 ) UseThisCall = false;

This fixes the problem.