### PR TITLE
Fixed Lobby.Joinable

### DIFF
--- a/Facepunch.Steamworks/Client/Lobby.cs
+++ b/Facepunch.Steamworks/Client/Lobby.cs
@@ -366,7 +366,7 @@ namespace Facepunch.Steamworks
             {
                 if ( !IsValid ) { return false; }
                 string joinable = CurrentLobbyData.GetData( "joinable" );
-                switch ( joinable )
+                switch ( joinable.ToLowerInvariant() )
                 {
                     case "true":
                         return true;


### PR DESCRIPTION
GetData("joinable") returns "True" or "False", (note upercase), so the Joinable would always return false.

Fixed by setting to LowerInvariant, since I'm not sure if it returns it uppercase on other platforms as well, or if this ever gets changed.