### PR TITLE
LobbyQuery FilterStringKeyValue method

### DIFF
--- a/Facepunch.Steamworks/SteamMatchmaking.cs
+++ b/Facepunch.Steamworks/SteamMatchmaking.cs
@@ -37,7 +37,7 @@ namespace Steamworks
 		{
 			LobbyInvite_t.Install( x => OnLobbyInvite?.Invoke( new Friend( x.SteamIDUser ), new Lobby( x.SteamIDLobby ) ) );
 
-			LobbyEnter_t.Install( x => OnLobbyEntered?.Invoke( new Lobby(x.SteamIDLobby ) ) );
+			LobbyEnter_t.Install( x => OnLobbyEntered?.Invoke( new Lobby( x.SteamIDLobby ) ) );
 
 			LobbyDataUpdate_t.Install( x =>
 			{

--- a/Facepunch.Steamworks/SteamMatchmaking.cs
+++ b/Facepunch.Steamworks/SteamMatchmaking.cs
@@ -12,12 +12,10 @@ namespace Steamworks
 	/// </summary>
 	public static class SteamMatchmaking
 	{
-		internal const int k_nMaxLobbyKeyLength = 255;
-
 		/// <summary>
 		/// Maximum number of characters a lobby metadata key can be
 		/// </summary>
-		public static int MaxLobbyKeyLength { get { return k_nMaxLobbyKeyLength; } }
+		internal static int MaxLobbyKeyLength => 255;
 
 
 		static ISteamMatchmaking _internal;

--- a/Facepunch.Steamworks/SteamMatchmaking.cs
+++ b/Facepunch.Steamworks/SteamMatchmaking.cs
@@ -12,6 +12,14 @@ namespace Steamworks
 	/// </summary>
 	public static class SteamMatchmaking
 	{
+		internal const int k_nMaxLobbyKeyLength = 255;
+
+		/// <summary>
+		/// Maximum number of characters a lobby metadata key can be
+		/// </summary>
+		public static int MaxLobbyKeyLength { get { return k_nMaxLobbyKeyLength; } }
+
+
 		static ISteamMatchmaking _internal;
 
 		internal static ISteamMatchmaking Internal

--- a/Facepunch.Steamworks/Structs/LobbyQuery.cs
+++ b/Facepunch.Steamworks/Structs/LobbyQuery.cs
@@ -51,21 +51,14 @@ namespace Steamworks.Data
 		/// </summary>
 		public LobbyQuery FilterStringKeyValue( string nKey, string nValue )
 		{
-			stringFilter = new MatchMakingKeyValuePair_t
+			if ( !string.IsNullOrEmpty(nKey) && nKey.Length <= SteamMatchmaking.MaxLobbyKeyLength )
 			{
-				Key = nKey,
-				Value = nValue
-			};
-
-			return this;
-		}
-
-		/// <summary>
-		/// Filter by specified key/value pair; MatchMakingKeyValuePair_t parameter
-		/// </summary>
-		public LobbyQuery FilterStringKeyValue( MatchMakingKeyValuePair_t kv )
-		{
-			stringFilter = kv;
+				stringFilter = new MatchMakingKeyValuePair_t
+				{
+					Key = nKey,
+					Value = nValue
+				};
+			}
 
 			return this;
 		}
@@ -98,6 +91,7 @@ namespace Steamworks.Data
 		}
 
 		#endregion
+
 
 		void ApplyFilters()
 		{

--- a/Facepunch.Steamworks/Structs/LobbyQuery.cs
+++ b/Facepunch.Steamworks/Structs/LobbyQuery.cs
@@ -43,6 +43,24 @@ namespace Steamworks.Data
 		}
 		#endregion
 
+		#region String key/value filter
+		internal MatchMakingKeyValuePair_t? stringFilter;
+
+		/// <summary>
+		/// Filter by specified key/value pair
+		/// </summary>
+		public LobbyQuery FilterStringKeyValue( string nKey, string nValue )
+		{
+			stringFilter = new MatchMakingKeyValuePair_t
+			{
+				Key = nKey,
+				Value = nValue
+			};
+
+			return this;
+		}
+		#endregion
+
 		#region Slots Filter
 		internal int? slotsAvailable;
 
@@ -71,7 +89,6 @@ namespace Steamworks.Data
 
 		#endregion
 
-
 		void ApplyFilters()
 		{
 			if ( distance.HasValue )
@@ -87,6 +104,11 @@ namespace Steamworks.Data
 			if ( maxResults.HasValue )
 			{
 				SteamMatchmaking.Internal.AddRequestLobbyListResultCountFilter( maxResults.Value );
+			}
+
+			if( stringFilter.HasValue )
+			{
+				SteamMatchmaking.Internal.AddRequestLobbyListStringFilter( stringFilter.Value.Key, stringFilter.Value.Value, LobbyComparison.Equal );
 			}
 		}
 

--- a/Facepunch.Steamworks/Structs/LobbyQuery.cs
+++ b/Facepunch.Steamworks/Structs/LobbyQuery.cs
@@ -59,6 +59,13 @@ namespace Steamworks.Data
 
 			return this;
 		}
+
+		public LobbyQuery FilterStringKeyValue ( MatchMakingKeyValuePair_t kv )
+		{
+			stringFilter = kv;
+
+			return this;
+		}
 		#endregion
 
 		#region Slots Filter

--- a/Facepunch.Steamworks/Structs/LobbyQuery.cs
+++ b/Facepunch.Steamworks/Structs/LobbyQuery.cs
@@ -47,7 +47,7 @@ namespace Steamworks.Data
 		internal MatchMakingKeyValuePair_t? stringFilter;
 
 		/// <summary>
-		/// Filter by specified key/value pair
+		/// Filter by specified key/value pair; string parameters
 		/// </summary>
 		public LobbyQuery FilterStringKeyValue( string nKey, string nValue )
 		{
@@ -60,6 +60,9 @@ namespace Steamworks.Data
 			return this;
 		}
 
+		/// <summary>
+		/// Filter by specified key/value pair; MatchMakingKeyValuePair_t parameter
+		/// </summary>
 		public LobbyQuery FilterStringKeyValue( MatchMakingKeyValuePair_t kv )
 		{
 			stringFilter = kv;

--- a/Facepunch.Steamworks/Structs/LobbyQuery.cs
+++ b/Facepunch.Steamworks/Structs/LobbyQuery.cs
@@ -60,7 +60,7 @@ namespace Steamworks.Data
 			return this;
 		}
 
-		public LobbyQuery FilterStringKeyValue ( MatchMakingKeyValuePair_t kv )
+		public LobbyQuery FilterStringKeyValue( MatchMakingKeyValuePair_t kv )
 		{
 			stringFilter = kv;
 

--- a/Facepunch.Steamworks/Structs/LobbyQuery.cs
+++ b/Facepunch.Steamworks/Structs/LobbyQuery.cs
@@ -54,16 +54,14 @@ namespace Steamworks.Data
 			if ( string.IsNullOrEmpty( nKey ) )
 				throw new System.ArgumentException( "Key string provided for LobbyQuery filter is null or empty", nameof( nKey ) );
 
-			if ( nKey.Length <= SteamMatchmaking.MaxLobbyKeyLength )
-			{
-				stringFilter = new MatchMakingKeyValuePair_t
-				{
-					Key = nKey,
-					Value = nValue
-				};
-			}
-			else
+			if ( nKey.Length > SteamMatchmaking.MaxLobbyKeyLength )
 				throw new System.ArgumentException( "Key length is longer than MaxLobbyKeyLength", nameof( nKey ) );
+
+			stringFilter = new MatchMakingKeyValuePair_t
+			{
+				Key = nKey,
+				Value = nValue
+			};
 
 			return this;
 		}

--- a/Facepunch.Steamworks/Structs/LobbyQuery.cs
+++ b/Facepunch.Steamworks/Structs/LobbyQuery.cs
@@ -51,7 +51,10 @@ namespace Steamworks.Data
 		/// </summary>
 		public LobbyQuery FilterStringKeyValue( string nKey, string nValue )
 		{
-			if ( !string.IsNullOrEmpty(nKey) && nKey.Length <= SteamMatchmaking.MaxLobbyKeyLength )
+			if ( string.IsNullOrEmpty( nKey ) )
+				throw new System.ArgumentException( "Key string provided for LobbyQuery filter is null or empty", nameof( nKey ) );
+
+			if ( nKey.Length <= SteamMatchmaking.MaxLobbyKeyLength )
 			{
 				stringFilter = new MatchMakingKeyValuePair_t
 				{
@@ -59,6 +62,8 @@ namespace Steamworks.Data
 					Value = nValue
 				};
 			}
+			else
+				throw new System.ArgumentException( "Key length is longer than MaxLobbyKeyLength", nameof( nKey ) );
 
 			return this;
 		}


### PR DESCRIPTION
Added LobbyQuery FilterStringKeyValue methods, fixed spacing on SteamMatchmaking.LobbyEnter_t.Install() parameter