### PR TITLE
LobbyQuery Numerical and NearVal Filters, SteamClient and Friend OwnsLobby

### DIFF
--- a/Facepunch.Steamworks/SteamClient.cs
+++ b/Facepunch.Steamworks/SteamClient.cs
@@ -171,11 +171,6 @@ namespace Steamworks
 		public static AppId AppId { get; internal set; }
 
 		/// <summary>
-		/// Check if this SteamClient owns the specified lobby
-		/// </summary>
-		public static bool OwnsLobby( Lobby k ) => k.Owner.Id == SteamId;
-
-		/// <summary>
 		/// Checks if your executable was launched through Steam and relaunches it through Steam if it wasn't
 		///  this returns true then it starts the Steam client if required and launches your game again through it, 
 		///  and you should quit your process as soon as possible. This effectively runs steam://run/AppId so it 

--- a/Facepunch.Steamworks/SteamClient.cs
+++ b/Facepunch.Steamworks/SteamClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using Steamworks.Data;
 
 namespace Steamworks
 {
@@ -105,7 +106,7 @@ namespace Steamworks
 			SteamParties.Shutdown();
 			SteamNetworkingUtils.Shutdown();
 			SteamNetworkingSockets.Shutdown();
-			
+
 			ServerList.Base.Shutdown();
 
 			SteamAPI.Shutdown();
@@ -168,6 +169,11 @@ namespace Steamworks
 		/// returns the appID of the current process
 		/// </summary>
 		public static AppId AppId { get; internal set; }
+
+		/// <summary>
+		/// Check if this SteamClient owns the specified lobby
+		/// </summary>
+		public static bool OwnsLobby( Lobby k ) => k.Owner.Id == SteamId;
 
 		/// <summary>
 		/// Checks if your executable was launched through Steam and relaunches it through Steam if it wasn't

--- a/Facepunch.Steamworks/Structs/Friend.cs
+++ b/Facepunch.Steamworks/Structs/Friend.cs
@@ -71,6 +71,11 @@ namespace Steamworks
 		/// </summary>
 		public bool IsSnoozing => State == FriendState.Snooze;
 
+		/// <summary>
+		/// Check if this Friend owns the specified lobby
+		/// </summary>
+		public bool OwnsLobby( Lobby k ) => k.Owner.Id == this.Id;
+
 
 
 		public Relationship Relationship => SteamFriends.Internal.GetFriendRelationship( Id );

--- a/Facepunch.Steamworks/Structs/Friend.cs
+++ b/Facepunch.Steamworks/Structs/Friend.cs
@@ -71,11 +71,6 @@ namespace Steamworks
 		/// </summary>
 		public bool IsSnoozing => State == FriendState.Snooze;
 
-		/// <summary>
-		/// Check if this Friend owns the specified lobby
-		/// </summary>
-		public bool OwnsLobby( Lobby k ) => k.Owner.Id == this.Id;
-
 
 
 		public Relationship Relationship => SteamFriends.Internal.GetFriendRelationship( Id );

--- a/Facepunch.Steamworks/Structs/Lobby.cs
+++ b/Facepunch.Steamworks/Structs/Lobby.cs
@@ -210,5 +210,9 @@ namespace Steamworks.Data
 			set => SteamMatchmaking.Internal.SetLobbyOwner( Id, value.Id );
 		}
 
+		/// <summary>
+		/// Check if the specified SteamId owns the lobby
+		/// </summary>
+		public bool IsOwnedBy( SteamId k ) => Owner.Id == k;
 	}
 }

--- a/Facepunch.Steamworks/Structs/LobbyQuery.cs
+++ b/Facepunch.Steamworks/Structs/LobbyQuery.cs
@@ -105,7 +105,7 @@ namespace Steamworks.Data
 		/// <summary>
 		/// Test key, initialize numerical filter dictionary if necessary, then add new numerical filter
 		/// </summary>
-		internal LobbyQuery AddNumericalFilter( string key, int value, LobbyComparison compare )
+		internal void AddNumericalFilter( string key, int value, LobbyComparison compare )
 		{
 			if ( string.IsNullOrEmpty( key ) )
 				throw new System.ArgumentException( "Key string provided for LobbyQuery filter is null or empty", nameof( key ) );
@@ -117,8 +117,6 @@ namespace Steamworks.Data
 				numericalFilters = new Dictionary<KeyValuePair<string, int>, LobbyComparison>();
 
 			numericalFilters.Add( new KeyValuePair<string, int>( key, value ), compare );
-
-			return this;
 		}
 		#endregion
 

--- a/Facepunch.Steamworks/Structs/LobbyQuery.cs
+++ b/Facepunch.Steamworks/Structs/LobbyQuery.cs
@@ -64,7 +64,7 @@ namespace Steamworks.Data
 		#endregion
 
 		#region Numerical filters
-		internal Dictionary<KeyValuePair<string, int>, LobbyComparison> numericalFilters;
+		internal List<NumericalFilter> numericalFilters;
 
 		/// <summary>
 		/// Numerical filter where value is less than the value provided
@@ -114,9 +114,9 @@ namespace Steamworks.Data
 				throw new System.ArgumentException( $"Key length is longer than {SteamMatchmaking.MaxLobbyKeyLength}", nameof( key ) );
 
 			if ( numericalFilters == null )
-				numericalFilters = new Dictionary<KeyValuePair<string, int>, LobbyComparison>();
+				numericalFilters = new List<NumericalFilter>();
 
-			numericalFilters.Add( new KeyValuePair<string, int>( key, value ), compare );
+			numericalFilters.Add( new NumericalFilter( key, value, compare ) );
 		}
 		#endregion
 
@@ -201,7 +201,7 @@ namespace Steamworks.Data
 			{
 				foreach ( var n in numericalFilters )
 				{
-					SteamMatchmaking.Internal.AddRequestLobbyListNumericalFilter( n.Key.Key, n.Key.Value, n.Value );
+					SteamMatchmaking.Internal.AddRequestLobbyListNumericalFilter( n.Key, n.Value, n.Comparer );
 				}
 			}
 

--- a/Facepunch.Steamworks/Structs/LobbyQuery.cs
+++ b/Facepunch.Steamworks/Structs/LobbyQuery.cs
@@ -7,11 +7,7 @@ namespace Steamworks.Data
 	{
 		// TODO FILTERS
 		// AddRequestLobbyListStringFilter
-		// - WithKeyValue, WithoutKeyValue
-		// AddRequestLobbyListNumericalFilter
-		// - WithLower, WithHigher, WithEqual, WithNotEqual
-		// AddRequestLobbyListNearValueFilter
-		// - OrderByNear
+		// - WithoutKeyValue
 
 		#region Distance Filter
 		internal LobbyDistanceFilter? distance;
@@ -67,6 +63,89 @@ namespace Steamworks.Data
 		}
 		#endregion
 
+		#region Numerical filters
+		internal Dictionary<KeyValuePair<string, int>, LobbyComparison> numericalFilters;
+
+		/// <summary>
+		/// Numerical filter where value is less than the value provided
+		/// </summary>
+		public LobbyQuery WithLower( string key, int value )
+		{
+			AddNumericalFilter( key, value, LobbyComparison.LessThan );
+			return this;
+		}
+
+		/// <summary>
+		/// Numerical filter where value is greater than the value provided
+		/// </summary>
+		public LobbyQuery WithHigher( string key, int value )
+		{
+			AddNumericalFilter( key, value, LobbyComparison.GreaterThan );
+			return this;
+		}
+
+		/// <summary>
+		/// Numerical filter where value must be equal to the value provided
+		/// </summary>
+		public LobbyQuery WithEqual( string key, int value )
+		{
+			AddNumericalFilter( key, value, LobbyComparison.Equal );
+			return this;
+		}
+
+		/// <summary>
+		/// Numerical filter where value must not equal the value provided
+		/// </summary>
+		public LobbyQuery WithNotEqual( string key, int value )
+		{
+			AddNumericalFilter( key, value, LobbyComparison.NotEqual );
+			return this;
+		}
+
+		/// <summary>
+		/// Test key, initialize numerical filter dictionary if necessary, then add new numerical filter
+		/// </summary>
+		internal LobbyQuery AddNumericalFilter( string key, int value, LobbyComparison compare )
+		{
+			if ( string.IsNullOrEmpty( key ) )
+				throw new System.ArgumentException( "Key string provided for LobbyQuery filter is null or empty", nameof( key ) );
+
+			if ( key.Length > SteamMatchmaking.MaxLobbyKeyLength )
+				throw new System.ArgumentException( $"Key length is longer than {SteamMatchmaking.MaxLobbyKeyLength}", nameof( key ) );
+
+			if ( numericalFilters == null )
+				numericalFilters = new Dictionary<KeyValuePair<string, int>, LobbyComparison>();
+
+			numericalFilters.Add( new KeyValuePair<string, int>( key, value ), compare );
+
+			return this;
+		}
+		#endregion
+
+		#region Near value filter
+		internal Dictionary<string, int> nearValFilters;
+
+		/// <summary>
+		/// Order filtered results according to key/values nearest the provided key/value pair.
+		/// Can specify multiple near value filters; each successive filter is lower priority than the previous.
+		/// </summary>
+		public LobbyQuery OrderByNear( string key, int value )
+		{
+			if ( string.IsNullOrEmpty( key ) )
+				throw new System.ArgumentException( "Key string provided for LobbyQuery filter is null or empty", nameof( key ) );
+
+			if ( key.Length > SteamMatchmaking.MaxLobbyKeyLength )
+				throw new System.ArgumentException( $"Key length is longer than {SteamMatchmaking.MaxLobbyKeyLength}", nameof( key ) );
+
+			if ( nearValFilters == null )
+				nearValFilters = new Dictionary<string, int>();
+
+			nearValFilters.Add( key, value );
+
+			return this;
+		}
+		#endregion
+
 		#region Slots Filter
 		internal int? slotsAvailable;
 
@@ -95,7 +174,6 @@ namespace Steamworks.Data
 
 		#endregion
 
-
 		void ApplyFilters()
 		{
 			if ( distance.HasValue )
@@ -118,6 +196,22 @@ namespace Steamworks.Data
 				foreach ( var k in stringFilters )
 				{
 					SteamMatchmaking.Internal.AddRequestLobbyListStringFilter( k.Key, k.Value, LobbyComparison.Equal );
+				}
+			}
+
+			if( numericalFilters != null )
+			{
+				foreach ( var n in numericalFilters )
+				{
+					SteamMatchmaking.Internal.AddRequestLobbyListNumericalFilter( n.Key.Key, n.Key.Value, n.Value );
+				}
+			}
+
+			if( nearValFilters != null )
+			{
+				foreach (var v in nearValFilters )
+				{
+					SteamMatchmaking.Internal.AddRequestLobbyListNearValueFilter( v.Key, v.Value );
 				}
 			}
 		}

--- a/Facepunch.Steamworks/Structs/LobbyQuery.cs
+++ b/Facepunch.Steamworks/Structs/LobbyQuery.cs
@@ -103,7 +103,7 @@ namespace Steamworks.Data
 		}
 
 		/// <summary>
-		/// Test key, initialize numerical filter dictionary if necessary, then add new numerical filter
+		/// Test key, initialize numerical filter list if necessary, then add new numerical filter
 		/// </summary>
 		internal void AddNumericalFilter( string key, int value, LobbyComparison compare )
 		{

--- a/Facepunch.Steamworks/Structs/NumericalFilter.cs
+++ b/Facepunch.Steamworks/Structs/NumericalFilter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Steamworks.Data
+{
+	struct NumericalFilter
+	{
+		public string Key { get; internal set; }
+		public int Value { get; internal set; }
+		public LobbyComparison Comparer { get; internal set; }
+
+		internal NumericalFilter ( string k, int v, LobbyComparison c )
+		{
+			Key = k;
+			Value = v;
+			Comparer = c;
+		}
+	}
+}

--- a/Facepunch.Steamworks/Structs/NumericalFilter.cs
+++ b/Facepunch.Steamworks/Structs/NumericalFilter.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Steamworks.Data
+﻿namespace Steamworks.Data
 {
 	struct NumericalFilter
 	{


### PR DESCRIPTION
Added LobbyQuery numerical filters for WithLower, WithHigher, WithEqual, and WithNotEqual; added OrderByNear for near value filters. Added OwnsLobby method to SteamClient and Friend which accepts a Lobby argument to test for ownership (replacing what I've been using: "if(SteamClient.SteamId == lobby.Owner.Id)")