### PR TITLE
Fix typo SteamNetworkingUtils.LocalTimestamp

### DIFF
--- a/Facepunch.Steamworks/SteamNetworkingUtils.cs
+++ b/Facepunch.Steamworks/SteamNetworkingUtils.cs
@@ -79,7 +79,7 @@ namespace Steamworks
 			}
 		}
 
-		public static long LocalTimetamp => Internal.GetLocalTimestamp();
+		public static long LocalTimestamp => Internal.GetLocalTimestamp();
 
 
 		/// <summary>


### PR DESCRIPTION
`SteamNetworkingUtils.LocalTimestamp` was spelled _LocalTimetamp_ before.