### PR TITLE
Fix SteamFriends.GetRichPresence(key, value)

### DIFF
--- a/Facepunch.Steamworks/SteamFriends.cs
+++ b/Facepunch.Steamworks/SteamFriends.cs
@@ -253,8 +253,12 @@ namespace Steamworks
 		/// </summary>
 		public static bool SetRichPresence( string key, string value )
 		{
-			richPresence[key] = value;
-			return Internal.SetRichPresence( key, value );
+			bool success = Internal.SetRichPresence( key, value );
+
+			if ( success ) 
+				richPresence[key] = value;
+
+			return success;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Adds key/value to the dictionary only if the rich presence was set successfully. Also fixes #307