### PR TITLE
Add unsafe overloads for SteamNetworking P2P send and recieve functions

### DIFF
--- a/Facepunch.Steamworks/SteamNetworking.cs
+++ b/Facepunch.Steamworks/SteamNetworking.cs
@@ -108,6 +108,24 @@ namespace Steamworks
 		}
 
 		/// <summary>
+		/// Reads in a packet that has been sent from another user via SendP2PPacket..
+		/// </summary>
+		public unsafe static bool ReadP2PPacket( byte[] buffer, ref uint size, ref SteamId steamid, int channel = 0 )
+		{
+      fixed (byte* p = buffer) {
+        return Internal.ReadP2PPacket( (IntPtr)p, (uint)buffer.Length, ref size, ref steamid, channel );
+      }
+		}
+
+		/// <summary>
+		/// Reads in a packet that has been sent from another user via SendP2PPacket..
+		/// </summary>
+		public unsafe static bool ReadP2PPacket( byte* buffer, uint cbuf, ref uint size, ref SteamId steamid, int channel = 0 )
+		{
+      return Internal.ReadP2PPacket( (IntPtr)buffer, cbuf, ref size, ref steamid, channel );
+		}
+
+		/// <summary>
 		/// Sends a P2P packet to the specified user.
 		/// This is a session-less API which automatically establishes NAT-traversing or Steam relay server connections.
 		/// NOTE: The first packet send may be delayed as the NAT-traversal code runs.
@@ -123,6 +141,15 @@ namespace Steamworks
 			}
 		}
 
+		/// <summary>
+		/// Sends a P2P packet to the specified user.
+		/// This is a session-less API which automatically establishes NAT-traversing or Steam relay server connections.
+		/// NOTE: The first packet send may be delayed as the NAT-traversal code runs.
+		/// </summary>
+		public static unsafe bool SendP2PPacket( SteamId steamid, byte* data, uint length, int nChannel = 1, P2PSend sendType = P2PSend.Reliable )
+		{
+      return Internal.SendP2PPacket( steamid, (IntPtr)data, (uint)length, (P2PSend)sendType, nChannel );
+		}
 
 	}
 }

--- a/Facepunch.Steamworks/SteamNetworking.cs
+++ b/Facepunch.Steamworks/SteamNetworking.cs
@@ -91,10 +91,10 @@ namespace Steamworks
 			var buffer = Helpers.TakeBuffer( (int) size );
 
 			fixed ( byte* p = buffer )
-            {
-                SteamId steamid = 1;
-                if ( !Internal.ReadP2PPacket( (IntPtr)p, (uint) buffer.Length, ref size, ref steamid, channel ) || size == 0 )
-                    return null;
+			{
+				SteamId steamid = 1;
+				if ( !Internal.ReadP2PPacket( (IntPtr)p, (uint) buffer.Length, ref size, ref steamid, channel ) || size == 0 )
+				    return null;
 
 				var data = new byte[size];
 				Array.Copy( buffer, 0, data, 0, size );
@@ -104,7 +104,7 @@ namespace Steamworks
 					SteamId = steamid,
 					Data = data
 				};
-            }
+			}
 		}
 
 		/// <summary>
@@ -112,9 +112,9 @@ namespace Steamworks
 		/// </summary>
 		public unsafe static bool ReadP2PPacket( byte[] buffer, ref uint size, ref SteamId steamid, int channel = 0 )
 		{
-      fixed (byte* p = buffer) {
-        return Internal.ReadP2PPacket( (IntPtr)p, (uint)buffer.Length, ref size, ref steamid, channel );
-      }
+			fixed (byte* p = buffer) {
+				return Internal.ReadP2PPacket( (IntPtr)p, (uint)buffer.Length, ref size, ref steamid, channel );
+			}
 		}
 
 		/// <summary>
@@ -122,7 +122,7 @@ namespace Steamworks
 		/// </summary>
 		public unsafe static bool ReadP2PPacket( byte* buffer, uint cbuf, ref uint size, ref SteamId steamid, int channel = 0 )
 		{
-      return Internal.ReadP2PPacket( (IntPtr)buffer, cbuf, ref size, ref steamid, channel );
+			return Internal.ReadP2PPacket( (IntPtr)buffer, cbuf, ref size, ref steamid, channel );
 		}
 
 		/// <summary>
@@ -147,8 +147,8 @@ namespace Steamworks
 		/// NOTE: The first packet send may be delayed as the NAT-traversal code runs.
 		/// </summary>
 		public static unsafe bool SendP2PPacket( SteamId steamid, byte* data, uint length, int nChannel = 1, P2PSend sendType = P2PSend.Reliable )
-		{
-      return Internal.SendP2PPacket( steamid, (IntPtr)data, (uint)length, (P2PSend)sendType, nChannel );
+		{ 
+			return Internal.SendP2PPacket( steamid, (IntPtr)data, (uint)length, (P2PSend)sendType, nChannel );
 		}
 
 	}


### PR DESCRIPTION
Adds unsafe overloads to SteamNetworking to avoid allocating garbage upon receiving messages. Some of these are thin wrappers around the actual internal call.

This is largely untested, but it's a trivial enough overload that it should work fine.

Also fixed the some indentation issues in the file.