### PR TITLE
Fixed sometimes false returned from SubscribeDownloadAsync

### DIFF
--- a/Facepunch.Steamworks/Structs/UgcItem.cs
+++ b/Facepunch.Steamworks/Structs/UgcItem.cs
@@ -278,11 +278,11 @@ namespace Steamworks.Ugc
 			while ( true )
 			{
 				if ( ct.IsCancellationRequested )
-					return false;
+					break;
 
 				progress?.Invoke( DownloadAmount );
 
-				if ( !IsDownloading )
+				if ( !IsDownloading && State.HasFlag( ItemState.Installed ) )
 					break;
 
 				await Task.Delay( milisecondsUpdateDelay );


### PR DESCRIPTION
After `if ( !IsDownloading) ` state is set to DownloadPending and NeedsUpdate (for a split second) resulting in method returning false. Little random and doesn't happen while debugging but this fixes it.