### PR TITLE
Added EntryCount to Leaderboard

### DIFF
--- a/Facepunch.Steamworks/Structs/Leaderboard.cs
+++ b/Facepunch.Steamworks/Structs/Leaderboard.cs
@@ -17,6 +17,7 @@ namespace Steamworks.Data
 		public string Name => SteamUserStats.Internal.GetLeaderboardName( Id );
 		public LeaderboardSort Sort => SteamUserStats.Internal.GetLeaderboardSortMethod( Id );
 		public LeaderboardDisplay Display => SteamUserStats.Internal.GetLeaderboardDisplayType( Id );
+        public int EntryCount => SteamUserStats.Internal.GetLeaderboardEntryCount(Id);
 
 		static int[] detailsBuffer = new int[64];
 		static int[] noDetails = new int[0];

--- a/Facepunch.Steamworks/Structs/Leaderboard.cs
+++ b/Facepunch.Steamworks/Structs/Leaderboard.cs
@@ -17,7 +17,7 @@ namespace Steamworks.Data
 		public string Name => SteamUserStats.Internal.GetLeaderboardName( Id );
 		public LeaderboardSort Sort => SteamUserStats.Internal.GetLeaderboardSortMethod( Id );
 		public LeaderboardDisplay Display => SteamUserStats.Internal.GetLeaderboardDisplayType( Id );
-        public int EntryCount => SteamUserStats.Internal.GetLeaderboardEntryCount(Id);
+		public int EntryCount => SteamUserStats.Internal.GetLeaderboardEntryCount(Id);
 
 		static int[] detailsBuffer = new int[64];
 		static int[] noDetails = new int[0];


### PR DESCRIPTION
ISteamUserStats.cs provides an internal method called GetLeaderboardEntryCount that retrieves the total number of entries for a given leaderboard.

Following the convention already established in Leaderboard.cs for the property Name, a property called EntryCount has been added to Leaderboard.cs that publicly surfaces the GetLeaderboardEntryCount method.

I have built this fork of Facepunch.Steamworks locally and tested this property successfully works in a Unity project.