### PR TITLE
Add OnSteamNetAuthenticationStatus and SteamServer.SteamId

### DIFF
--- a/Facepunch.Steamworks/SteamServer.cs
+++ b/Facepunch.Steamworks/SteamServer.cs
@@ -28,6 +28,7 @@ namespace Steamworks
 			Dispatch.Install<SteamServersConnected_t>( x => OnSteamServersConnected?.Invoke(), true );
 			Dispatch.Install<SteamServerConnectFailure_t>( x => OnSteamServerConnectFailure?.Invoke( x.Result, x.StillRetrying ), true );
 			Dispatch.Install<SteamServersDisconnected_t>( x => OnSteamServersDisconnected?.Invoke( x.Result ), true );
+			Dispatch.Install<SteamNetAuthenticationStatus_t>(x => OnSteamNetAuthenticationStatus?.Invoke(x.Avail), true);
 		}
 
 		/// <summary>
@@ -50,6 +51,11 @@ namespace Steamworks
 		/// Disconnected from Steam
 		/// </summary>
 		public static event Action<Result> OnSteamServersDisconnected;
+
+		/// <summary>
+		/// Called when authentication status changes, useful for grabbing SteamId once aavailability is current
+		/// </summary>
+		public static event Action<SteamNetworkingAvailability> OnSteamNetAuthenticationStatus;
 
 
 		/// <summary>
@@ -268,6 +274,8 @@ namespace Steamworks
 			}
 		}
 		private static string _gametags = "";
+
+		public static SteamId SteamId => Internal.GetSteamID();
 
 		/// <summary>
 		/// Log onto Steam anonymously.


### PR DESCRIPTION
I hunted for a good while for an existing method allowing a server to read its own SteamID (without parsing debug output), couldn't find anything.

So, I exposed the internal SteamId method as `SteamServer.SteamId`. I also added a dispatch listener for `SteamNetAuthenticationStatus_t` as `SteamServer.OnSteamNetAuthenticationStatus`

The reasoning for the listener is because it's a good opportunity to catch the server's SteamID the moment it's assigned. When the availability is equal to `SteamNetworkingAvailability.Current`, the SteamID is immediately available.

(My personal) use case is for relay server routing when a first-party matchmaking system is used. 