### PR TITLE
Interface approach for CreateRelaySocket

### DIFF
--- a/Facepunch.Steamworks/SteamNetworkingSockets.cs
+++ b/Facepunch.Steamworks/SteamNetworkingSockets.cs
@@ -167,6 +167,9 @@ namespace Steamworks
 
 		/// <summary>
 		/// Creates a server that will be relayed via Valve's network (hiding the IP and improving ping)
+		/// 
+		/// To use this derive a class from SocketManager and override as much as you want.
+		/// 
 		/// </summary>
 		public static T CreateRelaySocket<T>( int virtualport = 0 ) where T : SocketManager, new()
 		{
@@ -174,6 +177,31 @@ namespace Steamworks
 			var options = Array.Empty<NetKeyValue>();
 			t.Socket = Internal.CreateListenSocketP2P( virtualport, options.Length, options );
 			t.Initialize();
+			SetSocketManager( t.Socket.Id, t );
+			return t;
+		}
+
+		/// <summary>
+		/// Creates a server that will be relayed via Valve's network (hiding the IP and improving ping)
+		/// 
+		/// To use this you should pass a class that inherits ISocketManager. You can use
+		/// SocketManager to get connections and send messages, but the ISocketManager class
+		/// will received all the appropriate callbacks.
+		/// 
+		/// </summary>
+		public static SocketManager CreateRelaySocket( int virtualport, ISocketManager intrface )
+		{
+			var options = Array.Empty<NetKeyValue>();
+			var socket = Internal.CreateListenSocketP2P( virtualport, options.Length, options );
+
+			var t = new SocketManager
+			{
+				Socket = socket,
+				Interface = intrface
+			};
+
+			t.Initialize();
+
 			SetSocketManager( t.Socket.Id, t );
 			return t;
 		}


### PR DESCRIPTION
`SteamNetworkingSockets` exposes a way to create both normal socket server and relay socket server. The `CreateNormalSocket` supports both concrete class and interface approach when creating the server. However, for `CreateRelaySocket`, it does not have a way to use interface approach.

The interface approach is more convenient when building app using dependency injection framework so if `CreateNormalSocket` supports the interface approach, why not having `CreateRelaySocket` support it as well?