### PR TITLE
Steam Clans support

### DIFF
--- a/Facepunch.Steamworks.Test/ClanTest.cs
+++ b/Facepunch.Steamworks.Test/ClanTest.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Steamworks
+{
+    [DeploymentItem("steam_api64.dll")]
+    [DeploymentItem("steam_api.dll")]
+    [TestClass]
+    public class ClanTest
+    {
+        [TestMethod]
+        public void GetName()
+        {
+            var clan = new Clan(103582791433666425);
+
+            Assert.AreEqual("Steamworks Development", clan.Name);
+        }
+
+        [TestMethod]
+        public void GetClanTag()
+        {
+            var clan = new Clan(103582791433666425);
+
+            Assert.AreEqual("SteamworksDev", clan.Tag);
+        }
+
+        [TestMethod]
+        public async Task GetOwner()
+        {
+            var clan = new Clan(103582791433666425);
+            await clan.RequestOfficerList();
+
+            Assert.AreNotEqual(new SteamId(), clan.Owner.Id);
+        }
+
+        [TestMethod]
+        public void GetOfficers()
+        {
+            var clan = new Clan(103582791433666425);
+            foreach (var officer in clan.GetOfficers())
+            {
+                Console.WriteLine($"{officer.Name} : {officer.Id}");
+            }
+        }
+        
+        [TestMethod]
+        public async Task RequestOfficerList()
+        {
+            var clan = new Clan(103582791433666425);
+            bool res = await clan.RequestOfficerList();
+
+            Assert.AreEqual(true, res);
+        }
+    }
+}

--- a/Facepunch.Steamworks/SteamFriends.cs
+++ b/Facepunch.Steamworks/SteamFriends.cs
@@ -151,6 +151,14 @@ namespace Steamworks
 		    }
 		}
 
+		public static IEnumerable<Clan> GetClans()
+		{
+			for (int i = 0; i < Internal.GetClanCount(); i++)
+			{
+				yield return new Clan( Internal.GetClanByIndex( i ) );
+			}
+		}
+
 		/// <summary>
 		/// The dialog to open. Valid options are: 
 		/// "friends", 

--- a/Facepunch.Steamworks/Structs/Clan.cs
+++ b/Facepunch.Steamworks/Structs/Clan.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Steamworks
+{
+    public struct Clan
+    {
+        public SteamId Id;
+
+        public Clan(SteamId id)
+        {
+            Id = id;
+        }
+
+        public string Name => SteamFriends.Internal.GetClanName(Id);
+
+        public string Tag => SteamFriends.Internal.GetClanTag(Id);
+
+        public int ChatMemberCount => SteamFriends.Internal.GetClanChatMemberCount(Id);
+
+        public Friend Owner => new Friend(SteamFriends.Internal.GetClanOwner(Id));
+
+        public bool Public => SteamFriends.Internal.IsClanPublic(Id);
+
+        /// <summary>
+        /// Is the clan an official game group?
+        /// </summary>
+        public bool Official => SteamFriends.Internal.IsClanOfficialGameGroup(Id);
+
+        /// <summary>
+        /// Asynchronously fetches the officer list for a given clan
+        /// </summary>
+        /// <returns>Whether the request was successful or not</returns>
+        public async Task<bool> RequestOfficerList()
+        {
+            var req = await SteamFriends.Internal.RequestClanOfficerList(Id);
+            return req.HasValue && req.Value.Success != 0x0;
+        }
+
+        public IEnumerable<Friend> GetOfficers()
+        {
+            for (int i = 0; i < SteamFriends.Internal.GetClanOfficerCount(Id); i++)
+            {
+                yield return new Friend(SteamFriends.Internal.GetClanOfficerByIndex(Id, i));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Since none of the clan-related function were implemented (and I wanted to utilize the clan tags for a project), I've decided to implement some. 
All the clan functions reside in the Clan struct. A list of clans for the currently logged in user is also accessible via `SteamFriends.GetClans()`

Of course, not all clan functions are implemented yet, but the ones in here so far should be plenty enough for most people. 