### PR TITLE
Support return UGC metadata in query

### DIFF
--- a/Facepunch.Steamworks/Structs/UgcItem.cs
+++ b/Facepunch.Steamworks/Structs/UgcItem.cs
@@ -365,10 +365,15 @@ namespace Steamworks.Ugc
 		public ulong NumSecondsPlayedDuringTimePeriod { get; internal set; }
 		public ulong NumPlaytimeSessionsDuringTimePeriod { get; internal set; }
 
-        /// <summary>
-        /// The URL to the preview image for this item
-        /// </summary>
-        public string PreviewImageUrl { get; internal set; }
+		/// <summary>
+		/// The URL to the preview image for this item
+		/// </summary>
+		public string PreviewImageUrl { get; internal set; }
+
+		/// <summary>
+		/// The metadata string for this item
+		/// </summary>
+		public string Metadata { get; internal set; }
 
 		/// <summary>
 		/// Edit this item

--- a/Facepunch.Steamworks/Structs/UgcItem.cs
+++ b/Facepunch.Steamworks/Structs/UgcItem.cs
@@ -371,7 +371,7 @@ namespace Steamworks.Ugc
 		public string PreviewImageUrl { get; internal set; }
 
 		/// <summary>
-		/// The metadata string for this item
+		/// The metadata string for this item, only available from queries WithMetadata(true)
 		/// </summary>
 		public string Metadata { get; internal set; }
 

--- a/Facepunch.Steamworks/Structs/UgcQuery.cs
+++ b/Facepunch.Steamworks/Structs/UgcQuery.cs
@@ -151,6 +151,7 @@ namespace Steamworks.Ugc
 				CachedData = result.Value.CachedData,
 				ReturnsKeyValueTags = WantsReturnKeyValueTags ?? false,
 				ReturnsDefaultStats = WantsDefaultStats ?? true, //true by default
+				ReturnsMetadata = WantsReturnMetadata ?? false,
 			};
 		}
 

--- a/Facepunch.Steamworks/Structs/UgcResultPage.cs
+++ b/Facepunch.Steamworks/Structs/UgcResultPage.cs
@@ -14,6 +14,7 @@ namespace Steamworks.Ugc
 
 		internal bool ReturnsKeyValueTags;
 		internal bool ReturnsDefaultStats;
+		internal bool ReturnsMetadata;
 
 		public IEnumerable<Item> Entries
 		{
@@ -63,10 +64,17 @@ namespace Steamworks.Ugc
 							}
 						}
 
+						if (ReturnsMetadata)
+						{
+							string metadata;
+							if (SteamUGC.Internal.GetQueryUGCMetadata(Handle, i, out metadata))
+							{
+								item.Metadata = metadata;
+							}
+						}
+
 						// TODO GetQueryUGCAdditionalPreview
 						// TODO GetQueryUGCChildren
-						// TODO GetQueryUGCMetadata
-
 
 						yield return item;
 					}


### PR DESCRIPTION
Just a minor change to add support for getting the metadata of UGC items.

The TODO was a great help :) Since most of it was already there, I'm not sure if I am missing something here, since it feels a bit weird that it was left as a TODO but it works fine in the initial testing I have done.