### PR TITLE
Lobby.SendChatString() and OnChatMessage fix

### DIFF
--- a/Facepunch.Steamworks/Structs/Lobby.cs
+++ b/Facepunch.Steamworks/Structs/Lobby.cs
@@ -133,7 +133,8 @@ namespace Steamworks.Data
 		/// </summary>
 		public bool SendChatString( string message )
 		{
-			var data = System.Text.Encoding.UTF8.GetBytes( message );
+			//adding null terminator as it's used in Helpers.MemoryToString
+			var data = System.Text.Encoding.UTF8.GetBytes( message + '\0' );
 			return SendChatBytes( data );
 		}
 


### PR DESCRIPTION
Without null terminator in a message of Lobby.SendChatString - later on when reading it - the Helpers.MemoryToString  won't stop and returns invalid characters at the end of received one.

At start tried Helpers.TakeMemoryZeroedOut() in OnLobbyChatMessageRecievedAPI instead and also worked fine:
```
public static unsafe IntPtr TakeMemoryZeroedOut()
{
	lock ( MemoryPool )
	{
		var pool = TakeMemory();
		Unsafe.InitBlockUnaligned( pool.ToPointer(), 0, MemoryBufferSize );
		return pool;
	}
}
```