### PR TITLE
Fix race condition with async callresults

### DIFF
--- a/Facepunch.Steamworks/Callbacks/CallResult.cs
+++ b/Facepunch.Steamworks/Callbacks/CallResult.cs
@@ -35,7 +35,10 @@ namespace Steamworks
 		/// </summary>
 		public void OnCompleted( Action continuation )
 		{
-			Dispatch.OnCallComplete<T>( call, continuation, server );
+			if (IsCompleted)
+				continuation();
+			else
+				Dispatch.OnCallComplete<T>(call, continuation, server);
 		}
 
 		/// <summary>


### PR DESCRIPTION
The initial await on a call like CreateLobbyAsync will immediately call IsCompleted from that context. OnCompleted will be called later when the task actually starts running. If the SteamAPICallCompleted_t is posted in between those calls, we miss it since we didn't register our continuation yet so the task never finishes.