### PR TITLE
UgcEditor.SubmitAsync, on item created callback

### DIFF
--- a/Facepunch.Steamworks/Structs/UgcEditor.cs
+++ b/Facepunch.Steamworks/Structs/UgcEditor.cs
@@ -121,7 +121,7 @@ namespace Steamworks.Ugc
 			return this;
 		}
 
-		public async Task<PublishResult> SubmitAsync( IProgress<float> progress = null )
+		public async Task<PublishResult> SubmitAsync( IProgress<float> progress = null, Action<PublishResult> onItemCreated = null )
 		{
 			var result = default( PublishResult );
 
@@ -161,6 +161,9 @@ namespace Steamworks.Ugc
 				fileId = created.Value.PublishedFileId;
 				result.NeedsWorkshopAgreement = created.Value.UserNeedsToAcceptWorkshopLegalAgreement;
 				result.FileId = fileId;
+
+				if ( onItemCreated != null )
+					onItemCreated( result );
 			}
 
 


### PR DESCRIPTION
In my project this is required as I'm adding workshop id of created item to files of that item before updating it.

There are more use cases. For ex. currently when item creation succeeds but updating fails it's impossible to react properly as function only returns Result.Fail.