### PR TITLE
Replace for ToType<T> extension

### DIFF
--- a/Facepunch.Steamworks/Classes/Dispatch.cs
+++ b/Facepunch.Steamworks/Classes/Dispatch.cs
@@ -200,7 +200,7 @@ namespace Steamworks
 		/// </summary>
 		private static void ProcessResult( CallbackMsg_t msg )
 		{
-			var result = msg.Data.ToType<SteamAPICallCompleted_t>();
+			var result = msg.Data.ToUnmanagedType<SteamAPICallCompleted_t>();
 
 			//
 			// Do we have an entry added via OnCallComplete

--- a/Facepunch.Steamworks/Facepunch.Steamworks.Posix.csproj
+++ b/Facepunch.Steamworks/Facepunch.Steamworks.Posix.csproj
@@ -5,7 +5,6 @@
 		<DefineConstants>$(DefineConstants);PLATFORM_POSIX</DefineConstants>
 		<TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<LangVersion>7.1</LangVersion>	
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<RootNamespace>Steamworks</RootNamespace>

--- a/Facepunch.Steamworks/Facepunch.Steamworks.Win32.csproj
+++ b/Facepunch.Steamworks/Facepunch.Steamworks.Win32.csproj
@@ -5,7 +5,6 @@
 		<DefineConstants>$(DefineConstants);PLATFORM_WIN32;PLATFORM_WIN</DefineConstants>
 		<TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<LangVersion>7.1</LangVersion>	
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<RootNamespace>Steamworks</RootNamespace>

--- a/Facepunch.Steamworks/Facepunch.Steamworks.Win64.csproj
+++ b/Facepunch.Steamworks/Facepunch.Steamworks.Win64.csproj
@@ -5,7 +5,6 @@
 		<DefineConstants>$(DefineConstants);PLATFORM_WIN64;PLATFORM_WIN;PLATFORM_64</DefineConstants>
 		<TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<LangVersion>7.1</LangVersion>	
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<RootNamespace>Steamworks</RootNamespace>

--- a/Facepunch.Steamworks/Generated/Interfaces/ISteamNetworkingUtils.cs
+++ b/Facepunch.Steamworks/Generated/Interfaces/ISteamNetworkingUtils.cs
@@ -28,7 +28,7 @@ namespace Steamworks
 		internal NetMsg AllocateMessage( int cbAllocateBuffer )
 		{
 			var returnValue = _AllocateMessage( Self, cbAllocateBuffer );
-			return returnValue.ToType<NetMsg>();
+			return returnValue.ToUnmanagedType<NetMsg>();
 		}
 		
 		#region FunctionMeta

--- a/Facepunch.Steamworks/Networking/NetIdentity.cs
+++ b/Facepunch.Steamworks/Networking/NetIdentity.cs
@@ -100,7 +100,7 @@ namespace Steamworks.Data
 				var id = this;
 
 				var addrptr = InternalGetIPAddr( ref id );
-				return addrptr.ToType<NetAddress>();
+				return addrptr.ToUnmanagedType<NetAddress>();
 			}
 		}
 

--- a/Facepunch.Steamworks/Utility/Utility.cs
+++ b/Facepunch.Steamworks/Utility/Utility.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -16,6 +17,20 @@ namespace Steamworks
                 return default;
 
             return (T)Marshal.PtrToStructure( ptr, typeof( T ) );
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // Copy method body instead of call
+        static unsafe internal T ToUnmanagedType<T>(this IntPtr ptr) where T : unmanaged
+        {
+            if (ptr == IntPtr.Zero)
+                return default;
+
+            T dest;
+            long size = sizeof(T);
+            // Can be used other memcpy method with less overhead?
+            Buffer.MemoryCopy(ptr.ToPointer(), &dest, size, size);
+
+            return dest;
         }
 
         static internal object ToType( this IntPtr ptr, System.Type t )


### PR DESCRIPTION
Old extension uses `Marshal.PtrToStructure` which returns `object`(reference type) which needs to be collected with GC.
Todo: make `gameserveritem_t` compatible with `ToUnmanagedType`