### PR TITLE
Add game managed UGC Items

### DIFF
--- a/Facepunch.Steamworks/Structs/UgcEditor.cs
+++ b/Facepunch.Steamworks/Structs/UgcEditor.cs
@@ -43,7 +43,12 @@ namespace Steamworks.Ugc
 		/// Workshop item that is meant to be voted on for the purpose of selling in-game
 		/// </summary>
 		public static Editor NewMicrotransactionFile => new Editor( WorkshopFileType.Microtransaction );
-		
+
+		/// <summary>
+		/// Workshop item that is meant to be voted on for the purpose of selling in-game
+		/// </summary>
+		public static Editor NewMGameManagedFile => new Editor(WorkshopFileType.GameManagedItem);
+
 		public Editor ForAppId( AppId id ) { this.consumerAppId = id; return this; }
 
 		string Title;

--- a/Facepunch.Steamworks/Structs/UgcEditor.cs
+++ b/Facepunch.Steamworks/Structs/UgcEditor.cs
@@ -47,7 +47,7 @@ namespace Steamworks.Ugc
 		/// <summary>
 		/// Workshop item that is meant to be managed by the game. It is queryable by the API, but isn't visible on the web browser.
 		/// </summary>
-		public static Editor NewMGameManagedFile => new Editor(WorkshopFileType.GameManagedItem);
+		public static Editor NewGameManagedFile => new Editor(WorkshopFileType.GameManagedItem);
 
 		public Editor ForAppId( AppId id ) { this.consumerAppId = id; return this; }
 

--- a/Facepunch.Steamworks/Structs/UgcEditor.cs
+++ b/Facepunch.Steamworks/Structs/UgcEditor.cs
@@ -45,7 +45,7 @@ namespace Steamworks.Ugc
 		public static Editor NewMicrotransactionFile => new Editor( WorkshopFileType.Microtransaction );
 
 		/// <summary>
-		/// Workshop item that is meant to be voted on for the purpose of selling in-game
+		/// Workshop item that is meant to be managed by the game. It is queryable by the API, but isn't visible on the web browser.
 		/// </summary>
 		public static Editor NewMGameManagedFile => new Editor(WorkshopFileType.GameManagedItem);
 


### PR DESCRIPTION
The enum value was already there, I just needed hidden items in the workshop for replays. This allows you to create workshop items, that are hidden from users, but still queryable