### PR TITLE
Fix NuGet package generation

### DIFF
--- a/Facepunch.Steamworks/Facepunch.Steamworks.Win32.csproj
+++ b/Facepunch.Steamworks/Facepunch.Steamworks.Win32.csproj
@@ -23,13 +23,19 @@
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<RepositoryUrl>https://github.com/Facepunch/Facepunch.Steamworks.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Content Update="steam_api.dll" PackagePath="\content\" Pack="true" PackageCopyToOutput="true">
+		<None Include="Facepunch.Steamworks.jpg">
+			<Pack>true</Pack>
+			<PackagePath>/</PackagePath>
+		</None>
+		<None Include="steam_api.dll">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</Content>
-		<None Include="Facepunch.Steamworks.jpg" Pack="true" PackagePath="\" />
+			<Pack>true</Pack>
+			<PackagePath>content</PackagePath>
+		</None>
 	</ItemGroup>
 
 	<Import Project="Facepunch.Steamworks.targets" />

--- a/Facepunch.Steamworks/Facepunch.Steamworks.Win64.csproj
+++ b/Facepunch.Steamworks/Facepunch.Steamworks.Win64.csproj
@@ -23,19 +23,19 @@
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<RepositoryUrl>https://github.com/Facepunch/Facepunch.Steamworks.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>
   
 	<ItemGroup>
-		<Content Include="steam_api64.dll" PackagePath="\content\" Pack="true" PackageCopyToOutput="true">
-			<CopyToOutputDirectory></CopyToOutputDirectory>
-      </Content>
-      <None Include="Facepunch.Steamworks.jpg" Pack="true" PackagePath="\" />
-	</ItemGroup>
-  
-	<ItemGroup>
-	  <None Update="steam_api.dll">
-	    <CopyToOutputDirectory></CopyToOutputDirectory>
-	  </None>
+		<None Include="Facepunch.Steamworks.jpg">
+			<Pack>true</Pack>
+			<PackagePath>/</PackagePath>
+		</None>
+		<None Include="steam_api64.dll">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<Pack>true</Pack>
+			<PackagePath>content</PackagePath>
+		</None>
 	</ItemGroup>
 
 	<Import Project="Facepunch.Steamworks.targets" />


### PR DESCRIPTION
x64 build also copied 32-bit DLL.
Both packages didn't include their steam_api*dll when generated through VS.