### PR TITLE
Expose more clan chat features

### DIFF
--- a/Facepunch.Steamworks/SteamFriends.cs
+++ b/Facepunch.Steamworks/SteamFriends.cs
@@ -248,6 +248,18 @@ namespace Steamworks
 		public static void OpenGameInviteOverlay( SteamId lobby ) => Internal.ActivateGameOverlayInviteDialog( lobby );
 
 		/// <summary>
+		/// Opens the specified Steam group chat room in the Steam UI.
+		/// </summary>
+		/// <param name="clanid"></param>
+		public static void OpenClanChatWindowInSteam(SteamId clanid) => Internal.OpenClanChatWindowInSteam(clanid);
+
+		/// <summary>
+		/// Closes the specified Steam group chat room in the Steam UI.
+		/// </summary>
+		/// <param name="clanid"></param>
+		public static void CloseClanChatWindowInSteam(SteamId clanid) => Internal.CloseClanChatWindowInSteam(clanid);
+
+		/// <summary>
 		/// Mark a target user as 'played with'.
 		/// NOTE: The current user must be in game with the other player for the association to work.
 		/// </summary>

--- a/Facepunch.Steamworks/SteamFriends.cs
+++ b/Facepunch.Steamworks/SteamFriends.cs
@@ -47,9 +47,9 @@ namespace Steamworks
 		public static event Action<Friend, string, string> OnChatMessage;
 
 		/// <summary>
-		/// Called when a chat message has been received in a Steam group chat that we are in. Associated Functions: JoinClanChatRoom. (friend, msgtype, message)
+		/// Called when a chat message has been received in a Steam group chat that we are in. Associated Functions: JoinClanChatRoom. (clan, friend, msgtype, message)
 		/// </summary>
-		public static event Action<Friend, string, string> OnClanChatMessage;
+		public static event Action<Clan, Friend, string, string> OnClanChatMessage;
 
 		/// <summary>
 		/// Called when a user has joined a Steam group chat that the we are in. (clan, friend)
@@ -127,6 +127,7 @@ namespace Steamworks
 		{
 			if ( OnClanChatMessage == null ) return;
 
+			var clan = new Clan( data.SteamIDClanChat );
 			var friend = new Friend( data.SteamIDUser );
 
 			var buffer = Helpers.TakeMemory();
@@ -141,7 +142,7 @@ namespace Steamworks
 			var typeName = type.ToString();
 			var message = Helpers.MemoryToString( buffer );
 
-			OnClanChatMessage( friend, typeName, message );
+			OnClanChatMessage( clan, friend, typeName, message );
 		}
 
 		private static IEnumerable<Friend> GetFriendsWithFlag(FriendFlags flag)

--- a/Facepunch.Steamworks/SteamFriends.cs
+++ b/Facepunch.Steamworks/SteamFriends.cs
@@ -396,6 +396,11 @@ namespace Steamworks
 			return result.Value.ChatRoomEnterResponse == RoomEnter.Success ;
 		}
 
+		public static bool LeaveClanChatRoom(SteamId chatId)
+        {
+			return Internal.LeaveClanChatRoom(chatId);
+        }
+
 		public static bool SendClanChatRoomMessage( SteamId chatId, string message )
 		{
 			return Internal.SendClanChatMessage( chatId, message );

--- a/Facepunch.Steamworks/SteamFriends.cs
+++ b/Facepunch.Steamworks/SteamFriends.cs
@@ -31,6 +31,8 @@ namespace Steamworks
 			Dispatch.Install<GameRichPresenceJoinRequested_t>( x => OnGameRichPresenceJoinRequested?.Invoke( new Friend( x.SteamIDFriend), x.ConnectUTF8() ) );
 			Dispatch.Install<GameConnectedFriendChatMsg_t>( OnFriendChatMessage );
 			Dispatch.Install<GameConnectedClanChatMsg_t>( OnGameConnectedClanChatMessage );
+			Dispatch.Install<GameConnectedChatLeave_t>( x => OnClanChatLeave?.Invoke(new Clan(x.SteamIDClanChat), new Friend(x.SteamIDUser), x.Kicked, x.Dropped) );
+			Dispatch.Install<GameConnectedChatLeave_t>(x => OnClanChatJoin?.Invoke(new Clan(x.SteamIDClanChat), new Friend(x.SteamIDUser) ));
 			Dispatch.Install<GameOverlayActivated_t>( x => OnGameOverlayActivated?.Invoke( x.Active != 0 ) );
 			Dispatch.Install<GameServerChangeRequested_t>( x => OnGameServerChangeRequested?.Invoke( x.ServerUTF8(), x.PasswordUTF8() ) );
 			Dispatch.Install<GameLobbyJoinRequested_t>( x => OnGameLobbyJoinRequested?.Invoke( new Lobby( x.SteamIDLobby ), x.SteamIDFriend ) );
@@ -48,6 +50,16 @@ namespace Steamworks
 		/// Called when a chat message has been received in a Steam group chat that we are in. Associated Functions: JoinClanChatRoom. (friend, msgtype, message)
 		/// </summary>
 		public static event Action<Friend, string, string> OnClanChatMessage;
+
+		/// <summary>
+		/// Called when a user has joined a Steam group chat that the we are in. (clan, friend)
+		/// </summary>
+		public static event Action<Clan, Friend> OnClanChatJoin;
+
+		/// <summary>
+		/// Called when a user has left a Steam group chat that the we are in. (clan friend, kicked, dropped)
+		/// </summary>
+		public static event Action<Clan, Friend, bool, bool> OnClanChatLeave;
 
 		/// <summary>
 		/// called when a friends' status changes

--- a/Facepunch.Steamworks/Structs/Clan.cs
+++ b/Facepunch.Steamworks/Structs/Clan.cs
@@ -29,6 +29,12 @@ namespace Steamworks
         /// </summary>
         public bool Official => SteamFriends.Internal.IsClanOfficialGameGroup(Id);
 
+        public int Online => GetActivity().Online;
+
+        public int Chatting => GetActivity().Chatting;
+
+        public int InGame => GetActivity().InGame;
+
         /// <summary>
         /// Asynchronously fetches the officer list for a given clan
         /// </summary>
@@ -46,5 +52,33 @@ namespace Steamworks
                 yield return new Friend(SteamFriends.Internal.GetClanOfficerByIndex(Id, i));
             }
         }
+
+        public SteamId GetChatMember(int index)
+        {
+            return SteamFriends.Internal.GetChatMemberByIndex(Id, index);
+        }
+
+        public IEnumerable<SteamId> GetChatMembers()
+        {
+            for(int i = 0; i < ChatMemberCount; i++)
+            {
+                yield return GetChatMember(i);
+            }
+        }
+
+        private ClanActivity GetActivity()
+        {
+            var result = new ClanActivity();
+            SteamFriends.Internal.GetClanActivityCounts(Id, ref result.Online, ref result.InGame, ref result.Chatting);
+            return result;
+        }
+
+        private struct ClanActivity
+        {
+            public int Online;
+            public int InGame;
+            public int Chatting;
+        }
+
     }
 }

--- a/Facepunch.Steamworks/Structs/Clan.cs
+++ b/Facepunch.Steamworks/Structs/Clan.cs
@@ -53,12 +53,12 @@ namespace Steamworks
             }
         }
 
-        public SteamId GetChatMember(int index)
+        public Friend GetChatMember(int index)
         {
-            return SteamFriends.Internal.GetChatMemberByIndex(Id, index);
+            return new Friend(SteamFriends.Internal.GetChatMemberByIndex(Id, index));
         }
 
-        public IEnumerable<SteamId> GetChatMembers()
+        public IEnumerable<Friend> GetChatMembers()
         {
             for(int i = 0; i < ChatMemberCount; i++)
             {

--- a/Facepunch.Steamworks/Structs/JoinClanChatRoomResult.cs
+++ b/Facepunch.Steamworks/Structs/JoinClanChatRoomResult.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Steamworks.Structs
+{
+    public struct JoinClanChatRoomResult
+    {
+        public bool Success;
+        /// <summary>
+        /// SteamId of the clan chat. 
+        /// note: not the same as the clan's SteamId
+        /// </summary>
+        public SteamId Id;
+    }
+}


### PR DESCRIPTION
Steam's clan chat is weird, it's separate from what is accessible in the steam overlay.  When joining a clan chat it returns a new steamid of the clan chat room and isn't always interchangeable with the clan's steamid.  You can also send a message to the clan's steamid and upon receiving that message the steamid will be of the clan chat, not the clan.

Caused a little confusion here, could maybe make that more obvious but these changes make clan chat more usable.

And exposed Clan.Online/Chatting/InGame in a way that is simple for the user