### PR TITLE
Fixes typo in README Achievements code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ List them
 ```csharp
     foreach ( var a in SteamUserStats.Achievements )
     {
-        Console.WriteLine( $"{a.Name} ({a.State}})" );
+        Console.WriteLine( $"{a.Name} ({a.State})" );
     }	
 ```
 


### PR DESCRIPTION
Fixes a syntax error ( too many closing braces) in an code example on the README.