### PR TITLE
Expose message size in IsP2PPacketAvailable

### DIFF
--- a/Facepunch.Steamworks/SteamNetworking.cs
+++ b/Facepunch.Steamworks/SteamNetworking.cs
@@ -59,12 +59,21 @@ namespace Steamworks
 		public static bool CloseP2PSessionWithUser( SteamId user ) => Internal.CloseP2PSessionWithUser( user );
 
 		/// <summary>
-		/// Checks if a P2P packet is available to read, and gets the size of the message if there is one.
+		/// Checks if a P2P packet is available to read.
 		/// </summary>
 		public static bool IsP2PPacketAvailable( int channel = 0 )
 		{
 			uint _ = 0;
 			return Internal.IsP2PPacketAvailable( ref _, channel );
+		}
+		
+		/// <summary>
+		/// Checks if a P2P packet is available to read, and gets the size of the message if there is one.
+		/// </summary>
+		public static bool IsP2PPacketAvailable( out uint msgSize, int channel = 0 )
+		{
+			msgSize = 0;
+			return Internal.IsP2PPacketAvailable( ref msgSize, channel );
 		}
 
 		/// <summary>


### PR DESCRIPTION
This PR exposes a version of `IsP2PPacketAvailable` that also provides the size of the packet.

The original Steam API includes a the message size in `IsP2PPacketAvailable`. The current implementation deliberately drops it, because the main entry point using it (`ReadP2PPacket`) uses an internal buffering system (`Helpers.TakeBuffer`) that shields any user from having to use it... except when you want to manage your buffers yourself.

I am not sure if there are any other steps needed to move this PR forward, but please do let me know if I'm missing something.