### PR TITLE
Fix GC race condition in sending packets causing crash from steamworks

### DIFF
--- a/Facepunch.Steamworks/Networking/BroadcastBufferManager.cs
+++ b/Facepunch.Steamworks/Networking/BroadcastBufferManager.cs
@@ -60,7 +60,9 @@ namespace Steamworks
 		private static readonly Dictionary<IntPtr, ReferenceCounter> ReferenceCounters =
 			new Dictionary<IntPtr, ReferenceCounter>( 1024 );
 
-		public static readonly IntPtr FreeFunctionPointer = Marshal.GetFunctionPointerForDelegate<FreeFn>( Free );
+		private static readonly FreeFn FreeFunctionPin = new FreeFn( Free );
+
+		public static readonly IntPtr FreeFunctionPointer = Marshal.GetFunctionPointerForDelegate( FreeFunctionPin );
 
 		public static IntPtr Get( int size, int referenceCount )
 		{


### PR DESCRIPTION
Discovered race condition when accidentally sending 200k packets per second. It will cause a hard crash from steamworks, specifically...

``Process terminated. A callback was made on a garbage collected delegate of type 'Facepunch.Steamworks.Win64!Steamworks.BufferManager+FreeFn::Invoke'.``

You need to keep a reference to the delegate otherwise it gets garbage collected. [I've essentially followed the example of a pre net5.0 unmanaged to managed callback found in this microsoft blogpost](https://devblogs.microsoft.com/dotnet/improvements-in-native-code-interop-in-net-5-0/#unmanagedcallersonly). It's the first codeblock after the linked anchor.