### PR TITLE
Handle Steam not running better

### DIFF
--- a/Facepunch.Steamworks/SteamApps.cs
+++ b/Facepunch.Steamworks/SteamApps.cs
@@ -15,9 +15,12 @@ namespace Steamworks
 	{
 		internal static ISteamApps Internal => Interface as ISteamApps;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamApps( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
+
+			return true;
 		}
 
 		internal static void InstallEvents()

--- a/Facepunch.Steamworks/SteamClient.cs
+++ b/Facepunch.Steamworks/SteamClient.cs
@@ -73,8 +73,15 @@ namespace Steamworks
 		internal static void AddInterface<T>() where T : SteamClass, new()
 		{
 			var t = new T();
-			t.InitializeInterface( false );
-			openInterfaces.Add( t );
+			bool valid = t.InitializeInterface( false );
+			if ( valid )
+			{
+				openInterfaces.Add( t );
+			}
+			else
+			{
+				t.DestroyInterface( false );
+			}
 		}
 
 		static readonly List<SteamClass> openInterfaces = new List<SteamClass>();

--- a/Facepunch.Steamworks/SteamClient.cs
+++ b/Facepunch.Steamworks/SteamClient.cs
@@ -60,6 +60,8 @@ namespace Steamworks
 			AddInterface<SteamVideo>();
 			AddInterface<SteamRemotePlay>();
 
+			initialized = openInterfaces.Count > 0;
+
 			if ( asyncCallbacks )
 			{
 				//

--- a/Facepunch.Steamworks/SteamFriends.cs
+++ b/Facepunch.Steamworks/SteamFriends.cs
@@ -14,13 +14,16 @@ namespace Steamworks
 	{
 		internal static ISteamFriends Internal => Interface as ISteamFriends;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamFriends( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
 
 			richPresence = new Dictionary<string, string>();
 
 			InstallEvents();
+
+			return true;
 		}
 
 		static Dictionary<string, string> richPresence;

--- a/Facepunch.Steamworks/SteamInput.cs
+++ b/Facepunch.Steamworks/SteamInput.cs
@@ -1,4 +1,5 @@
-﻿using Steamworks.Data;
+﻿using System;
+using Steamworks.Data;
 using System.Collections.Generic;
 
 namespace Steamworks
@@ -7,9 +8,12 @@ namespace Steamworks
 	{
 		internal static ISteamInput Internal => Interface as ISteamInput;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamInput( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
+
+			return true;
 		}
 
 		internal const int STEAM_CONTROLLER_MAX_COUNT = 16;

--- a/Facepunch.Steamworks/SteamInventory.cs
+++ b/Facepunch.Steamworks/SteamInventory.cs
@@ -16,11 +16,14 @@ namespace Steamworks
 	{
 		internal static ISteamInventory Internal => Interface as ISteamInventory;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamInventory( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
 
 			InstallEvents( server );
+
+			return true;
 		}
 	
 		internal static void InstallEvents( bool server )

--- a/Facepunch.Steamworks/SteamMatchmaking.cs
+++ b/Facepunch.Steamworks/SteamMatchmaking.cs
@@ -14,11 +14,14 @@ namespace Steamworks
 	{
 		internal static ISteamMatchmaking Internal => Interface as ISteamMatchmaking;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamMatchmaking( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
 
 			InstallEvents();
+
+			return true;
 		}
 	
 		/// <summary>

--- a/Facepunch.Steamworks/SteamMatchmakingServers.cs
+++ b/Facepunch.Steamworks/SteamMatchmakingServers.cs
@@ -14,9 +14,12 @@ namespace Steamworks
 	{
 		internal static ISteamMatchmakingServers Internal => Interface as ISteamMatchmakingServers;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamMatchmakingServers( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
+
+			return true;
 		}
 	}
 }

--- a/Facepunch.Steamworks/SteamMusic.cs
+++ b/Facepunch.Steamworks/SteamMusic.cs
@@ -17,11 +17,13 @@ namespace Steamworks
 	{
 		internal static ISteamMusic Internal => Interface as ISteamMusic;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamMusic( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
 
 			InstallEvents();
+			return true;
 		}
 
 		internal static void InstallEvents()

--- a/Facepunch.Steamworks/SteamNetworking.cs
+++ b/Facepunch.Steamworks/SteamNetworking.cs
@@ -12,11 +12,14 @@ namespace Steamworks
 	{
 		internal static ISteamNetworking Internal => Interface as ISteamNetworking;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamNetworking( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
 
 			InstallEvents( server );
+
+			return true;
 		}
 
 		internal static void InstallEvents( bool server )

--- a/Facepunch.Steamworks/SteamNetworkingSockets.cs
+++ b/Facepunch.Steamworks/SteamNetworkingSockets.cs
@@ -31,10 +31,13 @@ namespace Steamworks
 			}
 		}
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamNetworkingSockets( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
+
 			InstallEvents( server );
+			return true;
 		}
 	
 #region SocketInterface

--- a/Facepunch.Steamworks/SteamNetworkingUtils.cs
+++ b/Facepunch.Steamworks/SteamNetworkingUtils.cs
@@ -14,10 +14,14 @@ namespace Steamworks
 	{
 		internal static ISteamNetworkingUtils Internal => Interface as ISteamNetworkingUtils;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamNetworkingUtils( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
+
 			InstallCallbacks( server );
+
+			return true;
 		}
 
 		static void InstallCallbacks( bool server )

--- a/Facepunch.Steamworks/SteamParental.cs
+++ b/Facepunch.Steamworks/SteamParental.cs
@@ -14,10 +14,14 @@ namespace Steamworks
 	{
 		internal static ISteamParentalSettings Internal => Interface as ISteamParentalSettings;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamParentalSettings( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
+
 			InstallEvents( server );
+
+			return true;
 		}
 
 		internal static void InstallEvents( bool server )

--- a/Facepunch.Steamworks/SteamParties.cs
+++ b/Facepunch.Steamworks/SteamParties.cs
@@ -17,10 +17,14 @@ namespace Steamworks
 	{
 		internal static ISteamParties Internal => Interface as ISteamParties;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamParties( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
+
 			InstallEvents( server );
+
+			return true;
 		}
 
 		internal void InstallEvents( bool server )

--- a/Facepunch.Steamworks/SteamRemotePlay.cs
+++ b/Facepunch.Steamworks/SteamRemotePlay.cs
@@ -14,11 +14,14 @@ namespace Steamworks
 	{
 		internal static ISteamRemotePlay Internal => Interface as ISteamRemotePlay;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamRemotePlay( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
 
 			InstallEvents( server );
+
+			return true;
 		}
 
 		internal void InstallEvents( bool server )

--- a/Facepunch.Steamworks/SteamRemoteStorage.cs
+++ b/Facepunch.Steamworks/SteamRemoteStorage.cs
@@ -14,9 +14,12 @@ namespace Steamworks
 	{
 		internal static ISteamRemoteStorage Internal => Interface as ISteamRemoteStorage;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamRemoteStorage( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
+
+			return true;
 		}
 		
 

--- a/Facepunch.Steamworks/SteamScreenshots.cs
+++ b/Facepunch.Steamworks/SteamScreenshots.cs
@@ -14,10 +14,14 @@ namespace Steamworks
 	{
 		internal static ISteamScreenshots Internal => Interface as ISteamScreenshots;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamScreenshots( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
+
 			InstallEvents();
+
+			return true;
 		}
 
 		internal static void InstallEvents()

--- a/Facepunch.Steamworks/SteamServer.cs
+++ b/Facepunch.Steamworks/SteamServer.cs
@@ -14,10 +14,14 @@ namespace Steamworks
 	{
 		internal static ISteamGameServer Internal => Interface as ISteamGameServer;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamGameServer( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
+
 			InstallEvents();
+
+			return true;
 		}
 
 		public static bool IsValid => Internal != null && Internal.IsValid;

--- a/Facepunch.Steamworks/SteamServerStats.cs
+++ b/Facepunch.Steamworks/SteamServerStats.cs
@@ -11,9 +11,12 @@ namespace Steamworks
 	{
 		internal static ISteamGameServerStats Internal => Interface as ISteamGameServerStats;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamGameServerStats( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
+
+			return true;
 		}
 		
 

--- a/Facepunch.Steamworks/SteamUgc.cs
+++ b/Facepunch.Steamworks/SteamUgc.cs
@@ -17,10 +17,14 @@ namespace Steamworks
 	{
 		internal static ISteamUGC Internal => Interface as ISteamUGC;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamUGC( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
+
 			InstallEvents( server );
+
+			return true;
 		}
 
 		internal static void InstallEvents( bool server )

--- a/Facepunch.Steamworks/SteamUser.cs
+++ b/Facepunch.Steamworks/SteamUser.cs
@@ -17,13 +17,17 @@ namespace Steamworks
 	{
 		internal static ISteamUser Internal => Interface as ISteamUser;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamUser( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
+
 			InstallEvents();
 
 			richPresence = new Dictionary<string, string>();
 			SampleRate = OptimalSampleRate;
+
+			return true;
 		}
 
 		static Dictionary<string, string> richPresence;

--- a/Facepunch.Steamworks/SteamUserStats.cs
+++ b/Facepunch.Steamworks/SteamUserStats.cs
@@ -11,11 +11,15 @@ namespace Steamworks
 	{
 		internal static ISteamUserStats Internal => Interface as ISteamUserStats;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamUserStats( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
+
 			InstallEvents();
 			RequestCurrentStats();
+
+			return true;
 		}
 
 		public static bool StatsRecieved { get; internal set; }

--- a/Facepunch.Steamworks/SteamUtils.cs
+++ b/Facepunch.Steamworks/SteamUtils.cs
@@ -14,10 +14,14 @@ namespace Steamworks
 	{
 		internal static ISteamUtils Internal => Interface as ISteamUtils;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamUtils( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
+
 			InstallEvents( server );
+
+			return true;
 		}
 
 		internal static void InstallEvents( bool server )

--- a/Facepunch.Steamworks/SteamVideo.cs
+++ b/Facepunch.Steamworks/SteamVideo.cs
@@ -14,10 +14,14 @@ namespace Steamworks
 	{
 		internal static ISteamVideo Internal => Interface as ISteamVideo;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamVideo( server ) );
+			if ( Interface.Self == IntPtr.Zero ) return false;
+
 			InstallEvents();
+
+			return true;
 		}
 
 		internal static void InstallEvents()

--- a/Facepunch.Steamworks/Utility/SteamInterface.cs
+++ b/Facepunch.Steamworks/Utility/SteamInterface.cs
@@ -55,7 +55,7 @@ namespace Steamworks
 
 	public abstract class SteamClass
 	{
-		internal abstract void InitializeInterface( bool server );
+		internal abstract bool InitializeInterface( bool server );
 		internal abstract void DestroyInterface( bool server );
 	}
 
@@ -65,9 +65,9 @@ namespace Steamworks
 		internal static SteamInterface InterfaceClient;
 		internal static SteamInterface InterfaceServer;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
-
+			return false;
 		}
 
 		internal virtual void SetInterface( bool server, SteamInterface iface )
@@ -101,9 +101,9 @@ namespace Steamworks
 	{
 		internal static SteamInterface Interface;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
-
+			return false;
 		}
 
 		internal virtual void SetInterface( bool server, SteamInterface iface )
@@ -124,9 +124,9 @@ namespace Steamworks
 	{
 		internal static SteamInterface Interface;
 
-		internal override void InitializeInterface( bool server )
+		internal override bool InitializeInterface( bool server )
 		{
-
+			return false;
 		}
 
 		internal virtual void SetInterface( bool server, SteamInterface iface )


### PR DESCRIPTION
Opening this up for potential discussion.

Handle Steam not running in a less crashy way, by bailing early during initialization. This should also allow devs to handle Steam not running better in their apps.

Does not handle closing Steam after initialization however.