### PR TITLE
Adjusted uploading progress bar so it doesn't jump back

### DIFF
--- a/Facepunch.Steamworks/Structs/UgcEditor.cs
+++ b/Facepunch.Steamworks/Structs/UgcEditor.cs
@@ -246,7 +246,7 @@ namespace Steamworks.Ugc
 							case ItemUpdateStatus.UploadingContent:
 								{
 									var uploaded = total > 0 ? ((float)processed / (float)total) : 0.0f;
-									progress?.Report( 0.2f + uploaded * 0.7f );
+									progress?.Report( 0.2f + uploaded * 0.6f );
 									break;
 								}
 							case ItemUpdateStatus.UploadingPreviewFile:


### PR DESCRIPTION
Adjusted uploading progress bar so it doesn't jump back after finishing uploading content.
(It jumps from 90% to 80% since progress was calculated using 0.2f + uploaded * 0.7f, I changed this to 0.2f + uploaded * 0.6f)