### PR TITLE
Fixed race condition caused by too many tasks using Helpers.TakeMemory simultaneously

### DIFF
--- a/Facepunch.Steamworks/Generated/Interfaces/ISteamAppList.cs
+++ b/Facepunch.Steamworks/Generated/Interfaces/ISteamAppList.cs
@@ -49,7 +49,7 @@ namespace Steamworks
 		#endregion
 		internal int GetAppName( AppId nAppID, out string pchName )
 		{
-			IntPtr mempchName = Helpers.TakeMemory();
+			using var mempchName = Helpers.TakeMemory();
 			var returnValue = _GetAppName( Self, nAppID, mempchName, (1024 * 32) );
 			pchName = Helpers.MemoryToString( mempchName );
 			return returnValue;
@@ -62,7 +62,7 @@ namespace Steamworks
 		#endregion
 		internal int GetAppInstallDir( AppId nAppID, out string pchDirectory )
 		{
-			IntPtr mempchDirectory = Helpers.TakeMemory();
+			using var mempchDirectory = Helpers.TakeMemory();
 			var returnValue = _GetAppInstallDir( Self, nAppID, mempchDirectory, (1024 * 32) );
 			pchDirectory = Helpers.MemoryToString( mempchDirectory );
 			return returnValue;

--- a/Facepunch.Steamworks/Generated/Interfaces/ISteamApps.cs
+++ b/Facepunch.Steamworks/Generated/Interfaces/ISteamApps.cs
@@ -159,7 +159,7 @@ namespace Steamworks
 		#endregion
 		internal bool BGetDLCDataByIndex( int iDLC, ref AppId pAppID, [MarshalAs( UnmanagedType.U1 )] ref bool pbAvailable, out string pchName )
 		{
-			IntPtr mempchName = Helpers.TakeMemory();
+			using var mempchName = Helpers.TakeMemory();
 			var returnValue = _BGetDLCDataByIndex( Self, iDLC, ref pAppID, ref pbAvailable, mempchName, (1024 * 32) );
 			pchName = Helpers.MemoryToString( mempchName );
 			return returnValue;
@@ -203,7 +203,7 @@ namespace Steamworks
 		#endregion
 		internal bool GetCurrentBetaName( out string pchName )
 		{
-			IntPtr mempchName = Helpers.TakeMemory();
+			using var mempchName = Helpers.TakeMemory();
 			var returnValue = _GetCurrentBetaName( Self, mempchName, (1024 * 32) );
 			pchName = Helpers.MemoryToString( mempchName );
 			return returnValue;
@@ -239,7 +239,7 @@ namespace Steamworks
 		#endregion
 		internal uint GetAppInstallDir( AppId appID, out string pchFolder )
 		{
-			IntPtr mempchFolder = Helpers.TakeMemory();
+			using var mempchFolder = Helpers.TakeMemory();
 			var returnValue = _GetAppInstallDir( Self, appID, mempchFolder, (1024 * 32) );
 			pchFolder = Helpers.MemoryToString( mempchFolder );
 			return returnValue;
@@ -330,7 +330,7 @@ namespace Steamworks
 		#endregion
 		internal int GetLaunchCommandLine( out string pszCommandLine )
 		{
-			IntPtr mempszCommandLine = Helpers.TakeMemory();
+			using var mempszCommandLine = Helpers.TakeMemory();
 			var returnValue = _GetLaunchCommandLine( Self, mempszCommandLine, (1024 * 32) );
 			pszCommandLine = Helpers.MemoryToString( mempszCommandLine );
 			return returnValue;

--- a/Facepunch.Steamworks/Generated/Interfaces/ISteamGameSearch.cs
+++ b/Facepunch.Steamworks/Generated/Interfaces/ISteamGameSearch.cs
@@ -82,7 +82,7 @@ namespace Steamworks
 		#endregion
 		internal GameSearchErrorCode_t RetrieveConnectionDetails( SteamId steamIDHost, out string pchConnectionDetails )
 		{
-			IntPtr mempchConnectionDetails = Helpers.TakeMemory();
+			using var mempchConnectionDetails = Helpers.TakeMemory();
 			var returnValue = _RetrieveConnectionDetails( Self, steamIDHost, mempchConnectionDetails, (1024 * 32) );
 			pchConnectionDetails = Helpers.MemoryToString( mempchConnectionDetails );
 			return returnValue;

--- a/Facepunch.Steamworks/Generated/Interfaces/ISteamInventory.cs
+++ b/Facepunch.Steamworks/Generated/Interfaces/ISteamInventory.cs
@@ -60,7 +60,7 @@ namespace Steamworks
 		#endregion
 		internal bool GetResultItemProperty( SteamInventoryResult_t resultHandle, uint unItemIndex, [MarshalAs( UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof( Utf8StringToNative ) )] string pchPropertyName, out string pchValueBuffer, ref uint punValueBufferSizeOut )
 		{
-			IntPtr mempchValueBuffer = Helpers.TakeMemory();
+			using var mempchValueBuffer = Helpers.TakeMemory();
 			var returnValue = _GetResultItemProperty( Self, resultHandle, unItemIndex, pchPropertyName, mempchValueBuffer, ref punValueBufferSizeOut );
 			pchValueBuffer = Helpers.MemoryToString( mempchValueBuffer );
 			return returnValue;
@@ -327,7 +327,7 @@ namespace Steamworks
 		#endregion
 		internal bool GetItemDefinitionProperty( InventoryDefId iDefinition, [MarshalAs( UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof( Utf8StringToNative ) )] string pchPropertyName, out string pchValueBuffer, ref uint punValueBufferSizeOut )
 		{
-			IntPtr mempchValueBuffer = Helpers.TakeMemory();
+			using var mempchValueBuffer = Helpers.TakeMemory();
 			var returnValue = _GetItemDefinitionProperty( Self, iDefinition, pchPropertyName, mempchValueBuffer, ref punValueBufferSizeOut );
 			pchValueBuffer = Helpers.MemoryToString( mempchValueBuffer );
 			return returnValue;

--- a/Facepunch.Steamworks/Generated/Interfaces/ISteamMatchmaking.cs
+++ b/Facepunch.Steamworks/Generated/Interfaces/ISteamMatchmaking.cs
@@ -266,8 +266,8 @@ namespace Steamworks
 		#endregion
 		internal bool GetLobbyDataByIndex( SteamId steamIDLobby, int iLobbyData, out string pchKey, out string pchValue )
 		{
-			IntPtr mempchKey = Helpers.TakeMemory();
-			IntPtr mempchValue = Helpers.TakeMemory();
+			using var mempchKey = Helpers.TakeMemory();
+			using var mempchValue = Helpers.TakeMemory();
 			var returnValue = _GetLobbyDataByIndex( Self, steamIDLobby, iLobbyData, mempchKey, (1024 * 32), mempchValue, (1024 * 32) );
 			pchKey = Helpers.MemoryToString( mempchKey );
 			pchValue = Helpers.MemoryToString( mempchValue );

--- a/Facepunch.Steamworks/Generated/Interfaces/ISteamNetworkingSockets.cs
+++ b/Facepunch.Steamworks/Generated/Interfaces/ISteamNetworkingSockets.cs
@@ -143,7 +143,7 @@ namespace Steamworks
 		#endregion
 		internal bool GetConnectionName( Connection hPeer, out string pszName )
 		{
-			IntPtr mempszName = Helpers.TakeMemory();
+			using var mempszName = Helpers.TakeMemory();
 			var returnValue = _GetConnectionName( Self, hPeer, mempszName, (1024 * 32) );
 			pszName = Helpers.MemoryToString( mempszName );
 			return returnValue;
@@ -223,7 +223,7 @@ namespace Steamworks
 		#endregion
 		internal int GetDetailedConnectionStatus( Connection hConn, out string pszBuf )
 		{
-			IntPtr mempszBuf = Helpers.TakeMemory();
+			using var mempszBuf = Helpers.TakeMemory();
 			var returnValue = _GetDetailedConnectionStatus( Self, hConn, mempszBuf, (1024 * 32) );
 			pszBuf = Helpers.MemoryToString( mempszBuf );
 			return returnValue;

--- a/Facepunch.Steamworks/Generated/Interfaces/ISteamNetworkingUtils.cs
+++ b/Facepunch.Steamworks/Generated/Interfaces/ISteamNetworkingUtils.cs
@@ -92,7 +92,7 @@ namespace Steamworks
 		#endregion
 		internal void ConvertPingLocationToString( ref NetPingLocation location, out string pszBuf )
 		{
-			IntPtr mempszBuf = Helpers.TakeMemory();
+			using var mempszBuf = Helpers.TakeMemory();
 			_ConvertPingLocationToString( Self, ref location, mempszBuf, (1024 * 32) );
 			pszBuf = Helpers.MemoryToString( mempszBuf );
 		}
@@ -395,7 +395,7 @@ namespace Steamworks
 		#endregion
 		internal void SteamNetworkingIPAddr_ToString( ref NetAddress addr, out string buf, [MarshalAs( UnmanagedType.U1 )] bool bWithPort )
 		{
-			IntPtr membuf = Helpers.TakeMemory();
+			using var membuf = Helpers.TakeMemory();
 			_SteamNetworkingIPAddr_ToString( Self, ref addr, membuf, (1024 * 32), bWithPort );
 			buf = Helpers.MemoryToString( membuf );
 		}
@@ -419,7 +419,7 @@ namespace Steamworks
 		#endregion
 		internal void SteamNetworkingIdentity_ToString( ref NetIdentity identity, out string buf )
 		{
-			IntPtr membuf = Helpers.TakeMemory();
+			using var membuf = Helpers.TakeMemory();
 			_SteamNetworkingIdentity_ToString( Self, ref identity, membuf, (1024 * 32) );
 			buf = Helpers.MemoryToString( membuf );
 		}

--- a/Facepunch.Steamworks/Generated/Interfaces/ISteamParties.cs
+++ b/Facepunch.Steamworks/Generated/Interfaces/ISteamParties.cs
@@ -50,7 +50,7 @@ namespace Steamworks
 		#endregion
 		internal bool GetBeaconDetails( PartyBeaconID_t ulBeaconID, ref SteamId pSteamIDBeaconOwner, ref SteamPartyBeaconLocation_t pLocation, out string pchMetadata )
 		{
-			IntPtr mempchMetadata = Helpers.TakeMemory();
+			using var mempchMetadata = Helpers.TakeMemory();
 			var returnValue = _GetBeaconDetails( Self, ulBeaconID, ref pSteamIDBeaconOwner, ref pLocation, mempchMetadata, (1024 * 32) );
 			pchMetadata = Helpers.MemoryToString( mempchMetadata );
 			return returnValue;
@@ -153,7 +153,7 @@ namespace Steamworks
 		#endregion
 		internal bool GetBeaconLocationData( SteamPartyBeaconLocation_t BeaconLocation, SteamPartyBeaconLocationData eData, out string pchDataStringOut )
 		{
-			IntPtr mempchDataStringOut = Helpers.TakeMemory();
+			using var mempchDataStringOut = Helpers.TakeMemory();
 			var returnValue = _GetBeaconLocationData( Self, BeaconLocation, eData, mempchDataStringOut, (1024 * 32) );
 			pchDataStringOut = Helpers.MemoryToString( mempchDataStringOut );
 			return returnValue;

--- a/Facepunch.Steamworks/Generated/Interfaces/ISteamUGC.cs
+++ b/Facepunch.Steamworks/Generated/Interfaces/ISteamUGC.cs
@@ -109,7 +109,7 @@ namespace Steamworks
 		#endregion
 		internal bool GetQueryUGCTag( UGCQueryHandle_t handle, uint index, uint indexTag, out string pchValue )
 		{
-			IntPtr mempchValue = Helpers.TakeMemory();
+			using var mempchValue = Helpers.TakeMemory();
 			var returnValue = _GetQueryUGCTag( Self, handle, index, indexTag, mempchValue, (1024 * 32) );
 			pchValue = Helpers.MemoryToString( mempchValue );
 			return returnValue;
@@ -123,7 +123,7 @@ namespace Steamworks
 		#endregion
 		internal bool GetQueryUGCTagDisplayName( UGCQueryHandle_t handle, uint index, uint indexTag, out string pchValue )
 		{
-			IntPtr mempchValue = Helpers.TakeMemory();
+			using var mempchValue = Helpers.TakeMemory();
 			var returnValue = _GetQueryUGCTagDisplayName( Self, handle, index, indexTag, mempchValue, (1024 * 32) );
 			pchValue = Helpers.MemoryToString( mempchValue );
 			return returnValue;
@@ -137,7 +137,7 @@ namespace Steamworks
 		#endregion
 		internal bool GetQueryUGCPreviewURL( UGCQueryHandle_t handle, uint index, out string pchURL )
 		{
-			IntPtr mempchURL = Helpers.TakeMemory();
+			using var mempchURL = Helpers.TakeMemory();
 			var returnValue = _GetQueryUGCPreviewURL( Self, handle, index, mempchURL, (1024 * 32) );
 			pchURL = Helpers.MemoryToString( mempchURL );
 			return returnValue;
@@ -151,7 +151,7 @@ namespace Steamworks
 		#endregion
 		internal bool GetQueryUGCMetadata( UGCQueryHandle_t handle, uint index, out string pchMetadata )
 		{
-			IntPtr mempchMetadata = Helpers.TakeMemory();
+			using var mempchMetadata = Helpers.TakeMemory();
 			var returnValue = _GetQueryUGCMetadata( Self, handle, index, mempchMetadata, (1024 * 32) );
 			pchMetadata = Helpers.MemoryToString( mempchMetadata );
 			return returnValue;
@@ -200,8 +200,8 @@ namespace Steamworks
 		#endregion
 		internal bool GetQueryUGCAdditionalPreview( UGCQueryHandle_t handle, uint index, uint previewIndex, out string pchURLOrVideoID, out string pchOriginalFileName, ref ItemPreviewType pPreviewType )
 		{
-			IntPtr mempchURLOrVideoID = Helpers.TakeMemory();
-			IntPtr mempchOriginalFileName = Helpers.TakeMemory();
+			using var mempchURLOrVideoID = Helpers.TakeMemory();
+			using var mempchOriginalFileName = Helpers.TakeMemory();
 			var returnValue = _GetQueryUGCAdditionalPreview( Self, handle, index, previewIndex, mempchURLOrVideoID, (1024 * 32), mempchOriginalFileName, (1024 * 32), ref pPreviewType );
 			pchURLOrVideoID = Helpers.MemoryToString( mempchURLOrVideoID );
 			pchOriginalFileName = Helpers.MemoryToString( mempchOriginalFileName );
@@ -227,8 +227,8 @@ namespace Steamworks
 		#endregion
 		internal bool GetQueryUGCKeyValueTag( UGCQueryHandle_t handle, uint index, uint keyValueTagIndex, out string pchKey, out string pchValue )
 		{
-			IntPtr mempchKey = Helpers.TakeMemory();
-			IntPtr mempchValue = Helpers.TakeMemory();
+			using var mempchKey = Helpers.TakeMemory();
+			using var mempchValue = Helpers.TakeMemory();
 			var returnValue = _GetQueryUGCKeyValueTag( Self, handle, index, keyValueTagIndex, mempchKey, (1024 * 32), mempchValue, (1024 * 32) );
 			pchKey = Helpers.MemoryToString( mempchKey );
 			pchValue = Helpers.MemoryToString( mempchValue );
@@ -243,7 +243,7 @@ namespace Steamworks
 		#endregion
 		internal bool GetQueryUGCKeyValueTag( UGCQueryHandle_t handle, uint index, [MarshalAs( UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof( Utf8StringToNative ) )] string pchKey, out string pchValue )
 		{
-			IntPtr mempchValue = Helpers.TakeMemory();
+			using var mempchValue = Helpers.TakeMemory();
 			var returnValue = _GetQueryUGCKeyValueTag( Self, handle, index, pchKey, mempchValue, (1024 * 32) );
 			pchValue = Helpers.MemoryToString( mempchValue );
 			return returnValue;
@@ -832,7 +832,7 @@ namespace Steamworks
 		#endregion
 		internal bool GetItemInstallInfo( PublishedFileId nPublishedFileID, ref ulong punSizeOnDisk, out string pchFolder, ref uint punTimeStamp )
 		{
-			IntPtr mempchFolder = Helpers.TakeMemory();
+			using var mempchFolder = Helpers.TakeMemory();
 			var returnValue = _GetItemInstallInfo( Self, nPublishedFileID, ref punSizeOnDisk, mempchFolder, (1024 * 32), ref punTimeStamp );
 			pchFolder = Helpers.MemoryToString( mempchFolder );
 			return returnValue;

--- a/Facepunch.Steamworks/Generated/Interfaces/ISteamUser.cs
+++ b/Facepunch.Steamworks/Generated/Interfaces/ISteamUser.cs
@@ -93,7 +93,7 @@ namespace Steamworks
 		#endregion
 		internal bool GetUserDataFolder( out string pchBuffer )
 		{
-			IntPtr mempchBuffer = Helpers.TakeMemory();
+			using var mempchBuffer = Helpers.TakeMemory();
 			var returnValue = _GetUserDataFolder( Self, mempchBuffer, (1024 * 32) );
 			pchBuffer = Helpers.MemoryToString( mempchBuffer );
 			return returnValue;

--- a/Facepunch.Steamworks/Generated/Interfaces/ISteamUserStats.cs
+++ b/Facepunch.Steamworks/Generated/Interfaces/ISteamUserStats.cs
@@ -433,7 +433,7 @@ namespace Steamworks
 		#endregion
 		internal int GetMostAchievedAchievementInfo( out string pchName, ref float pflPercent, [MarshalAs( UnmanagedType.U1 )] ref bool pbAchieved )
 		{
-			IntPtr mempchName = Helpers.TakeMemory();
+			using var mempchName = Helpers.TakeMemory();
 			var returnValue = _GetMostAchievedAchievementInfo( Self, mempchName, (1024 * 32), ref pflPercent, ref pbAchieved );
 			pchName = Helpers.MemoryToString( mempchName );
 			return returnValue;
@@ -446,7 +446,7 @@ namespace Steamworks
 		#endregion
 		internal int GetNextMostAchievedAchievementInfo( int iIteratorPrevious, out string pchName, ref float pflPercent, [MarshalAs( UnmanagedType.U1 )] ref bool pbAchieved )
 		{
-			IntPtr mempchName = Helpers.TakeMemory();
+			using var mempchName = Helpers.TakeMemory();
 			var returnValue = _GetNextMostAchievedAchievementInfo( Self, iIteratorPrevious, mempchName, (1024 * 32), ref pflPercent, ref pbAchieved );
 			pchName = Helpers.MemoryToString( mempchName );
 			return returnValue;

--- a/Facepunch.Steamworks/Generated/Interfaces/ISteamUtils.cs
+++ b/Facepunch.Steamworks/Generated/Interfaces/ISteamUtils.cs
@@ -256,7 +256,7 @@ namespace Steamworks
 		#endregion
 		internal bool GetEnteredGamepadTextInput( out string pchText )
 		{
-			IntPtr mempchText = Helpers.TakeMemory();
+			using var mempchText = Helpers.TakeMemory();
 			var returnValue = _GetEnteredGamepadTextInput( Self, mempchText, (1024 * 32) );
 			pchText = Helpers.MemoryToString( mempchText );
 			return returnValue;
@@ -370,7 +370,7 @@ namespace Steamworks
 		#endregion
 		internal int FilterText( TextFilteringContext eContext, SteamId sourceSteamID, [MarshalAs( UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof( Utf8StringToNative ) )] string pchInputMessage, out string pchOutFilteredText )
 		{
-			IntPtr mempchOutFilteredText = Helpers.TakeMemory();
+			using var mempchOutFilteredText = Helpers.TakeMemory();
 			var returnValue = _FilterText( Self, eContext, sourceSteamID, pchInputMessage, mempchOutFilteredText, (1024 * 32) );
 			pchOutFilteredText = Helpers.MemoryToString( mempchOutFilteredText );
 			return returnValue;

--- a/Facepunch.Steamworks/Generated/Interfaces/ISteamVideo.cs
+++ b/Facepunch.Steamworks/Generated/Interfaces/ISteamVideo.cs
@@ -60,7 +60,7 @@ namespace Steamworks
 		#endregion
 		internal bool GetOPFStringForApp( AppId unVideoAppID, out string pchBuffer, ref int pnBufferSize )
 		{
-			IntPtr mempchBuffer = Helpers.TakeMemory();
+			using var mempchBuffer = Helpers.TakeMemory();
 			var returnValue = _GetOPFStringForApp( Self, unVideoAppID, mempchBuffer, ref pnBufferSize );
 			pchBuffer = Helpers.MemoryToString( mempchBuffer );
 			return returnValue;

--- a/Facepunch.Steamworks/Networking/NetAddress.cs
+++ b/Facepunch.Steamworks/Networking/NetAddress.cs
@@ -147,7 +147,7 @@ namespace Steamworks.Data
 
 		public override string ToString()
 		{
-			var ptr = Helpers.TakeMemory();
+			using var ptr = Helpers.TakeMemory();
 			var self = this;
 			InternalToString( ref self, ptr, Helpers.MemoryBufferSize, true );
 			return Helpers.MemoryToString( ptr );

--- a/Facepunch.Steamworks/SteamFriends.cs
+++ b/Facepunch.Steamworks/SteamFriends.cs
@@ -97,7 +97,7 @@ namespace Steamworks
 
 			var friend = new Friend( data.SteamIDUser );
 
-			var buffer = Helpers.TakeMemory();
+			using var buffer = Helpers.TakeMemory();
 			var type = ChatEntryType.ChatMsg;
 
 			var len = Internal.GetFriendMessage( data.SteamIDUser, data.MessageID, buffer, Helpers.MemoryBufferSize, ref type );
@@ -117,7 +117,7 @@ namespace Steamworks
 
 			var friend = new Friend( data.SteamIDUser );
 
-			var buffer = Helpers.TakeMemory();
+			using var buffer = Helpers.TakeMemory();
 			var type = ChatEntryType.ChatMsg;
 			SteamId chatter = data.SteamIDUser;
 

--- a/Facepunch.Steamworks/SteamMatchmaking.cs
+++ b/Facepunch.Steamworks/SteamMatchmaking.cs
@@ -72,7 +72,7 @@ namespace Steamworks
 		{
 			SteamId steamid = default;
 			ChatEntryType chatEntryType = default;
-			var buffer = Helpers.TakeMemory();
+			using var buffer = Helpers.TakeMemory();
 
 			var readData = Internal.GetLobbyChatEntry( callback.SteamIDLobby, (int)callback.ChatID, ref steamid, buffer, Helpers.MemoryBufferSize, ref chatEntryType );
 

--- a/Generator/CodeWriter/Interface.cs
+++ b/Generator/CodeWriter/Interface.cs
@@ -152,7 +152,7 @@ namespace Generator
 				{
 					if ( arg is FetchStringType sb )
 					{
-						WriteLine( $"IntPtr mem{sb.VarName} = Helpers.TakeMemory();" );
+						WriteLine( $"using var mem{sb.VarName} = Helpers.TakeMemory();" );
 					}
 				}
 


### PR DESCRIPTION
I ran into this issue by having a few too many tasks querying UGC item metadata at the same time, and luckily noticed that I was either getting empty strings or a null character at the start of my strings, indicating that there was a race condition here. Perhaps I'm simply misusing the library here by relying on parallelism on Ugc.Item too much, but I figured that if this library is going to make me use async then it's probably so I can use it this way.