### PR TITLE
SteamFriends and SteamUser Changes

### DIFF
--- a/Facepunch.Steamworks.Test/Facepunch.Steamworks.TestWin32.csproj
+++ b/Facepunch.Steamworks.Test/Facepunch.Steamworks.TestWin32.csproj
@@ -45,9 +45,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0-beta4" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0-beta4" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.2-beta1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="ClanTest.cs" />

--- a/Facepunch.Steamworks.Test/Facepunch.Steamworks.TestWin64.csproj
+++ b/Facepunch.Steamworks.Test/Facepunch.Steamworks.TestWin64.csproj
@@ -44,9 +44,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0-beta4" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0-beta4" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.2-beta1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="ClanTest.cs" />

--- a/Facepunch.Steamworks/Generated/SteamEnums.cs
+++ b/Facepunch.Steamworks/Generated/SteamEnums.cs
@@ -546,7 +546,7 @@ namespace Steamworks
 	//
 	// EPersonaChange
 	//
-	internal enum PersonaChange : int
+	public enum PersonaChange : int
 	{
 		Name = 1,
 		Status = 2,

--- a/Facepunch.Steamworks/SteamFriends.cs
+++ b/Facepunch.Steamworks/SteamFriends.cs
@@ -27,7 +27,7 @@ namespace Steamworks
 
 		internal void InstallEvents()
 		{
-			Dispatch.Install<PersonaStateChange_t>( x => OnPersonaStateChange?.Invoke( new Friend( x.SteamID ) ) );
+			Dispatch.Install<PersonaStateChange_t>( x => OnPersonaStateChange?.Invoke( new Friend( x.SteamID ), (PersonaChange)x.ChangeFlags ) );
 			Dispatch.Install<GameRichPresenceJoinRequested_t>( x => OnGameRichPresenceJoinRequested?.Invoke( new Friend( x.SteamIDFriend), x.ConnectUTF8() ) );
 			Dispatch.Install<GameConnectedFriendChatMsg_t>( OnFriendChatMessage );
 			Dispatch.Install<GameConnectedClanChatMsg_t>( OnGameConnectedClanChatMessage );
@@ -52,7 +52,7 @@ namespace Steamworks
 		/// <summary>
 		/// called when a friends' status changes
 		/// </summary>
-		public static event Action<Friend> OnPersonaStateChange;
+		public static event Action<Friend, PersonaChange> OnPersonaStateChange;
 
 
 		/// <summary>

--- a/Facepunch.Steamworks/SteamUser.cs
+++ b/Facepunch.Steamworks/SteamUser.cs
@@ -435,6 +435,12 @@ namespace Steamworks
 		public static bool IsPhoneRequiringVerification => Internal.BIsPhoneRequiringVerification();
 
 		/// <summary>
+		/// Sets the rich presence data for an unsecured game server that the user is playing on.
+		/// This allows friends to be able to view the game info and join your game.
+		/// </summary>
+		public static void AdvertiseGame( SteamId steamId, uint ipServer, ushort portServer ) => Internal.AdvertiseGame( steamId, ipServer, portServer );
+
+		/// <summary>
 		/// Requests an application ticket encrypted with the secret "encrypted app ticket key".
 		/// The encryption key can be obtained from the Encrypted App Ticket Key page on the App Admin for your app.
 		/// There can only be one call pending, and this call is subject to a 60 second rate limit.

--- a/Generator/Cleanup.cs
+++ b/Generator/Cleanup.cs
@@ -113,6 +113,7 @@ public static class Cleanup
 
 	internal static string Expose( string name )
 	{
+		if ( name == "PersonaChange" ) return "public";
 		if ( name == "FriendState" ) return "public";
 		if ( name == "MusicStatus" ) return "public";
 		if ( name == "ParentalFeature" ) return "public";

--- a/Generator/CodeWriter/CodeWriter.cs
+++ b/Generator/CodeWriter/CodeWriter.cs
@@ -80,9 +80,9 @@ namespace Generator
             }
 
 			{
-			//	GenerateGlobalFunctions( "SteamAPI", $"{folder}../Generated/SteamAPI.cs" );
-			//	GenerateGlobalFunctions( "SteamGameServer", $"{folder}../Generated/SteamGameServer.cs" );
-			//	GenerateGlobalFunctions( "SteamInternal", $"{folder}../Generated/SteamInternal.cs" );
+				//	GenerateGlobalFunctions( "SteamAPI", $"{folder}../Generated/SteamAPI.cs" );
+				//	GenerateGlobalFunctions( "SteamGameServer", $"{folder}../Generated/SteamGameServer.cs" );
+				//	GenerateGlobalFunctions( "SteamInternal", $"{folder}../Generated/SteamInternal.cs" );
 			}
 
             foreach ( var iface in def.Interfaces )

--- a/Generator/Generator.csproj
+++ b/Generator/Generator.csproj
@@ -7,7 +7,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="steam_sdk\steam_api.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -20,9 +20,9 @@ namespace Generator
 
 			var generator = new CodeWriter( def );
 
-            generator.ToFolder( "../Facepunch.Steamworks/Generated/" );
+            generator.ToFolder( "../../../../Facepunch.Steamworks/Generated/" );
         }
-    }
+	}
 }
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Another c# Steamworks implementation](https://wiki.facepunch.com/steamworks/)
 
-![Build All](https://github.com/Crytilis/Facepunch.Steamworks/workflows/Build%20All/badge.svg)
+![Build All](https://github.com/Facepunch/Facepunch.Steamworks/workflows/Build%20All/badge.svg)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Facepunch.Steamworks
 
-[Another fucking c# Steamworks implementation](https://wiki.facepunch.com/steamworks/)
+[Another c# Steamworks implementation](https://wiki.facepunch.com/steamworks/)
 
 ![Build All](https://github.com/Crytilis/Facepunch.Steamworks/workflows/Build%20All/badge.svg)
 


### PR DESCRIPTION
This PR would implement the following changes as listed on the commits;

- Added AdvertiseGame to SteamUser so that it may be used for clients.
- PersonaChange enum is now set to public rather than internal so it may used with the PersonaStateChange callback.
- Modified the PersonaStateChange callback for SteamFriends to include the PersonaStateChange_t flag as defined in the PersonaChange enum.
- Removed the F word from the readme in the event that prospective employers are looking at a forked GitHub.