### PR TITLE
Fix for GetFloat on struct Steamworks.Data.Stat always returning 0

### DIFF
--- a/Facepunch.Steamworks/Structs/Stat.cs
+++ b/Facepunch.Steamworks/Structs/Stat.cs
@@ -92,7 +92,7 @@ namespace Steamworks.Data
 				SteamUserStats.Internal.GetStat( Name, ref val );
 			}
 
-			return 0;
+			return val;
 		}
 
 		public int GetInt()


### PR DESCRIPTION
Steamworks.Data.Stat instance "GetFloat" and SteamUserStats static "GetStatFloat" does not behave the same. 

GetFloat on the struct always returns 0. This fixes that