### PR TITLE
Include libsteam_api in both intel64 and m1 builds

### DIFF
--- a/UnityPlugin/redistributable_bin/osx/libsteam_api.bundle.meta
+++ b/UnityPlugin/redistributable_bin/osx/libsteam_api.bundle.meta
@@ -26,7 +26,8 @@ PluginImporter:
       Standalone: OSXUniversal
     second:
       enabled: 1
-      settings: {}
+      settings:
+        CPU: AnyCPU
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
Fixes #591 

What was the issue?
`libsteam_api.bundle` was not included in `intel 64 + m1` builds, since it's marked as only compatible with `intel 64` based on the old file format before Unity added the m1 support.

Here we mark it compatible with `intel 64 + m1` and now the bundle is included in `intel 64 + m1` builds.

In the visual editor the changes are equivalent to changing:
<img width="572" alt="image" src="https://user-images.githubusercontent.com/762297/145827825-078de94c-a85a-4f96-8add-807c5755281a.png">


Just tested on a Mac Mini. M1 will still fail with `libsteam_api` not found, but intel builds have Steam included. So it's a half-working solution until the `libsteam_api.bundle` is updated. Intel macs will be able to connect to Steam.
