### PR TITLE
Update README to be clear about m1 mac support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 |----------|------------ |
 | Windows | ✔ |
 | Linux | ✔ |
-| MacOS | ✔ (M1 not supported) |
+| MacOS (Intel) | ✔ |
+| MacOS (Apple Silicon) | ❌ |
 | Unity Support | ✔ |
 | Unity IL2CPP Support | ✔ |
 | Async Callbacks (steam callresults) | ✔ |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 |----------|------------ |
 | Windows | ✔ |
 | Linux | ✔ |
-| MacOS | ✔ |
+| MacOS | ✔ (M1 not supported) |
 | Unity Support | ✔ |
 | Unity IL2CPP Support | ✔ |
 | Async Callbacks (steam callresults) | ✔ |


### PR DESCRIPTION
A small update to the readme so that it clearly states that m1 support isn't there. Figured this would be a quite neccessary change since it's confirmed that m1 support isn't planned, so this change is really important in order to avoid people using the project without realizing that a platform they need to support won't work at all.