### PR TITLE
Check return value from FileRead

### DIFF
--- a/Facepunch.Steamworks/SteamRemoteStorage.cs
+++ b/Facepunch.Steamworks/SteamRemoteStorage.cs
@@ -48,6 +48,10 @@ namespace Steamworks
 			fixed ( byte* ptr = buffer )
 			{
 				var readsize = Internal.FileRead( filename, (IntPtr)ptr, size );
+				if ( readsize != size )
+				{
+					return null;
+				}
 				return buffer;
 			}
 		}


### PR DESCRIPTION
Without this check we might return an uninitialized buffer if FileRead fails.