### PR TITLE
Adds back .Net 4.6 support, can build solution cross-platform

### DIFF
--- a/Facepunch.Steamworks.Test/Facepunch.Steamworks.TestWin32.csproj
+++ b/Facepunch.Steamworks.Test/Facepunch.Steamworks.TestWin32.csproj
@@ -34,6 +34,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Facepunch.Steamworks\Facepunch.Steamworks.Win32.csproj" />
@@ -48,8 +49,15 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0-beta4" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0-beta4" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.2-beta1" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="ClanTest.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Microsoft.NETFramework.ReferenceAssemblies.net462" />
   </ItemGroup>
 </Project>

--- a/Facepunch.Steamworks.Test/Facepunch.Steamworks.TestWin32.csproj
+++ b/Facepunch.Steamworks.Test/Facepunch.Steamworks.TestWin32.csproj
@@ -44,10 +44,10 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0-beta4" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0-beta4" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.2-beta1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="ClanTest.cs" />

--- a/Facepunch.Steamworks.Test/Facepunch.Steamworks.TestWin64.csproj
+++ b/Facepunch.Steamworks.Test/Facepunch.Steamworks.TestWin64.csproj
@@ -33,6 +33,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Facepunch.Steamworks\Facepunch.Steamworks.Win64.csproj" />
@@ -47,8 +48,15 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0-beta4" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0-beta4" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.2-beta1" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="ClanTest.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Microsoft.NETFramework.ReferenceAssemblies.net462" />
   </ItemGroup>
 </Project>

--- a/Facepunch.Steamworks.Test/Facepunch.Steamworks.TestWin64.csproj
+++ b/Facepunch.Steamworks.Test/Facepunch.Steamworks.TestWin64.csproj
@@ -43,10 +43,10 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0-beta4" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0-beta4" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.2-beta1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="ClanTest.cs" />

--- a/Facepunch.Steamworks.Test/packages.config
+++ b/Facepunch.Steamworks.Test/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="2.0.0-beta4" targetFramework="net46" />
+  <package id="MSTest.TestFramework" version="2.0.0-beta4" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.2-beta1" targetFramework="net452" />
+</packages>

--- a/Facepunch.Steamworks/Facepunch.Steamworks.Posix.csproj
+++ b/Facepunch.Steamworks/Facepunch.Steamworks.Posix.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<AssemblyName>Facepunch.Steamworks.Posix</AssemblyName>
 		<DefineConstants>$(DefineConstants);PLATFORM_POSIX</DefineConstants>
-		<TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net6.0;net46</TargetFrameworks>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<LangVersion>10</LangVersion>	
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Facepunch.Steamworks/Facepunch.Steamworks.Win32.csproj
+++ b/Facepunch.Steamworks/Facepunch.Steamworks.Win32.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<AssemblyName>Facepunch.Steamworks.Win32</AssemblyName>
 		<DefineConstants>$(DefineConstants);PLATFORM_WIN32;PLATFORM_WIN</DefineConstants>
-		<TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net6.0;net46</TargetFrameworks>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>	
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/Facepunch.Steamworks/Facepunch.Steamworks.Win32.csproj
+++ b/Facepunch.Steamworks/Facepunch.Steamworks.Win32.csproj
@@ -26,6 +26,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+	  <None Remove="Microsoft.NETFramework.ReferenceAssemblies.net462" />
+	</ItemGroup>
+	<ItemGroup>
 		<None Include="Facepunch.Steamworks.jpg">
 			<Pack>true</Pack>
 			<PackagePath>/</PackagePath>
@@ -37,6 +40,12 @@
 		</None>
 	</ItemGroup>
 
+	<ItemGroup>
+	  <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3">
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	    <PrivateAssets>all</PrivateAssets>
+	  </PackageReference>
+	</ItemGroup>
 	<Import Project="Facepunch.Steamworks.targets" />
 
 </Project>

--- a/Facepunch.Steamworks/Facepunch.Steamworks.Win64.csproj
+++ b/Facepunch.Steamworks/Facepunch.Steamworks.Win64.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<AssemblyName>Facepunch.Steamworks.Win64</AssemblyName>
 		<DefineConstants>$(DefineConstants);PLATFORM_WIN64;PLATFORM_WIN;PLATFORM_64</DefineConstants>
-		<TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net6.0;net46</TargetFrameworks>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>	
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/Facepunch.Steamworks/Facepunch.Steamworks.Win64.csproj
+++ b/Facepunch.Steamworks/Facepunch.Steamworks.Win64.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
 	<PropertyGroup>
 		<AssemblyName>Facepunch.Steamworks.Win64</AssemblyName>
 		<DefineConstants>$(DefineConstants);PLATFORM_WIN64;PLATFORM_WIN;PLATFORM_64</DefineConstants>
@@ -26,6 +25,9 @@
 	</PropertyGroup>
   
 	<ItemGroup>
+	  <None Remove="Microsoft.NETFramework.ReferenceAssemblies.net462" />
+	</ItemGroup>
+	<ItemGroup>
 		<None Include="Facepunch.Steamworks.jpg">
 			<Pack>true</Pack>
 			<PackagePath>/</PackagePath>
@@ -37,6 +39,12 @@
 		</None>
 	</ItemGroup>
 
+	<ItemGroup>
+	  <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3">
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	    <PrivateAssets>all</PrivateAssets>
+	  </PackageReference>
+	</ItemGroup>
 	<Import Project="Facepunch.Steamworks.targets" />
 
 	<Target Name="PostBuildHome" AfterTargets="PostBuildEvent" Condition="'$(Computername)'=='GarryBasementPc'">

--- a/Generator/Generator.csproj
+++ b/Generator/Generator.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/Generator/packages.config
+++ b/Generator/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This PR contains two things:
* It reverts the changes committed by Dependabot here (https://github.com/Facepunch/Facepunch.Steamworks/commit/e81d1ac682cee74f84f4a4c967887dce35d18ecd) that removed .Net 4.6 support. This is still needed by Unity as that is the latest .Net Framework level supported.
* It adds the .Net 4.6 ReferenceAssemblies nuget package to all of the windows projects in the solution. This enables building the solution for this framework level even on machines that do not have the developer packs installed for this version. It particularly helps for macOS and likely Unix machines to be able to build this solution as those framework developer SDKs are not available to install on those platforms.

Together this enables building the solution on macOS and using the output assemblies in a Unity project. For us this fixed an issue using this library from the latest released version [2.3.2](https://github.com/Facepunch/Facepunch.Steamworks/releases/tag/2.3.2) (over two years old).