### PR TITLE
Initialize Steam Input so it actually works

### DIFF
--- a/Facepunch.Steamworks/SteamInput.cs
+++ b/Facepunch.Steamworks/SteamInput.cs
@@ -14,6 +14,7 @@ namespace Steamworks
 		internal override bool InitializeInterface( bool server )
 		{
 			SetInterface( server, new ISteamInput( server ) );
+			Internal.Init( false );
 			if ( Interface.Self == IntPtr.Zero ) return false;
 
 			return true;


### PR DESCRIPTION
SteamInput has to be initialized separately from the rest of Steamworks, or it doesn't work.

Once initialized, it actually works.