### PR TITLE
Fixes #553 OnNewLaunchParameters never getting called

### DIFF
--- a/Facepunch.Steamworks/SteamApps.cs
+++ b/Facepunch.Steamworks/SteamApps.cs
@@ -20,6 +20,8 @@ namespace Steamworks
 			SetInterface( server, new ISteamApps( server ) );
 			if ( Interface.Self == IntPtr.Zero ) return false;
 
+			InstallEvents();
+
 			return true;
 		}
 


### PR DESCRIPTION
Super simple fix for OnNewLaunchParameters never getting called. Assuming InstallEvents was just forgotten in the SteamApps class. Guess not a lot of people are using that callback :P 

Fixes #553 