### PR TITLE
Directory exists, file exists checks separation

### DIFF
--- a/Facepunch.Steamworks/Structs/UgcEditor.cs
+++ b/Facepunch.Steamworks/Structs/UgcEditor.cs
@@ -138,15 +138,7 @@ namespace Steamworks.Ugc
 			//
 			// Checks
 			//
-			if ( ContentFolder != null )
-			{
-				if ( !System.IO.Directory.Exists( ContentFolder.FullName ) )
-					throw new System.Exception( $"UgcEditor - Content Folder doesn't exist ({ContentFolder.FullName})" );
-
-				if ( !ContentFolder.EnumerateFiles( "*", System.IO.SearchOption.AllDirectories ).Any() )
-					throw new System.Exception( $"UgcEditor - Content Folder is empty" );
-			}
-
+			PerformValidityChecks();
 
 			//
 			// Item Create
@@ -282,6 +274,29 @@ namespace Steamworks.Ugc
 			}
 
 			return result;
+		}
+
+		private void PerformValidityChecks()
+		{
+			if ( ContentFolder == null )
+				return;
+
+			var fileAttributes = System.IO.File.GetAttributes( ContentFolder.FullName );
+			var isFolder = fileAttributes.HasFlag( System.IO.FileAttributes.Directory );
+
+			if ( isFolder )
+			{
+				if ( !ContentFolder.Exists )
+					throw new System.Exception( $"UgcEditor - Content Folder doesn't exist ({ContentFolder.FullName})" );
+
+				if ( !ContentFolder.EnumerateFiles( "*", System.IO.SearchOption.AllDirectories ).Any() )
+					throw new System.Exception( $"UgcEditor - Content Folder is empty" );
+			}
+			else
+			{
+				if ( !ContentFolder.Exists )
+					throw new System.Exception( $"UgcEditor - Content Path for file doesn't exist ({ContentFolder.FullName})" );
+			}
 		}
 	}
 


### PR DESCRIPTION
When trying to upload a file (instead of a directory) on Steam with the newest update, the plugin was throwing an error, saying that the directory doesn't exist.

This PR should resolve the problem, distinguishing a file from a folder while checking for its existence.