### PR TITLE
Fix InventoryDef.Properties causing NullReferenceException

### DIFF
--- a/Facepunch.Steamworks/Structs/InventoryDef.cs
+++ b/Facepunch.Steamworks/Structs/InventoryDef.cs
@@ -95,7 +95,7 @@ namespace Steamworks
 		/// </summary>
 		public string GetProperty( string name )
 		{
-			if ( _properties!= null && _properties.TryGetValue( name, out string val ) )
+			if (name != null && _properties!= null && _properties.TryGetValue( name, out string val ) )
 				return val;
 
 			uint _ = (uint)Helpers.MaxStringSize;


### PR DESCRIPTION
Fixes #747 