### PR TITLE
Added WithDifferentApp to set consumer and creator App Id for UGCQuery

### DIFF
--- a/Facepunch.Steamworks/Structs/UgcQuery.cs
+++ b/Facepunch.Steamworks/Structs/UgcQuery.cs
@@ -202,6 +202,13 @@ namespace Steamworks.Ugc
 			excludedTags.Add( tag );
 			return this;
 		}
+		
+		public QueryType WithDifferentApp( AppId consumerAppId, AppId creatorAppId )
+		{
+			consumerApp = consumerAppId;
+			creatorApp = creatorAppId;
+			return this;
+		}
 
 		void ApplyConstraints( UGCQueryHandle_t handle )
 		{


### PR DESCRIPTION
This adds the ability to change the app you are querying items from. 

It is useful when you have a tool for uploading/editing workshop items then a different game app that downloads and consumes them. These variables where already set just not editable in any way.


I couldn't write any tests for this as I am unaware of what app ids have permissions to upload stuff to the Rust workshop so I only have "works on my machine" when I tested it on my own apps.

Also fixes issue #685 