### PR TITLE
Unbreak build status image in README.md (ultra minor pr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Another fucking c# Steamworks implementation](https://wiki.facepunch.com/steamworks/)
 
-![Build All](https://github.com/Crytilis/Facepunch.Steamworks/workflows/Build%20All/badge.svg)
+![Build All](https://github.com/Facepunch/Facepunch.Steamworks/actions/workflows/dotnetcore.yml/badge.svg)
 
 ## Features
 


### PR DESCRIPTION
Super minor PR but I love seeing build statuses in projects.

It looks like the previous name 'build all' was an alias for the `dotnetcore.yml` path which github wanted instead. 
This has been updated to reflect the (what I assume to be) correct URL.

A few assumptions have been made here:
- The pipeline has been migrated to the `Facepunch` project (this project)
- The Build All that was listed in the build status was the same build all listed in the project's Actions -> Workflows

![Build All](https://github.com/Facepunch/Facepunch.Steamworks/actions/workflows/dotnetcore.yml/badge.svg)