### PR TITLE
Expose API for additional workshop preview files

### DIFF
--- a/Facepunch.Steamworks/Structs/UgcEditor.cs
+++ b/Facepunch.Steamworks/Structs/UgcEditor.cs
@@ -69,6 +69,24 @@ namespace Steamworks.Ugc
 		string PreviewFile;
 		public Editor WithPreviewFile( string t ) { this.PreviewFile = t; return this; }
 
+		List<(string, ItemPreviewType)> AdditionalPreviewFiles;
+		
+		List<int> RemovePreviewFiles;
+
+		public Editor AddAdditionalPreviewFile( string f, ItemPreviewType t )
+		{
+			AdditionalPreviewFiles ??= new List<(string, ItemPreviewType)>();
+			AdditionalPreviewFiles.Add((f, t));
+			return this;
+		}
+		
+		public Editor RemoveAdditionalPreviewFile( int i )
+		{
+			RemovePreviewFiles ??= new List<int>();
+			RemovePreviewFiles.Add(i);
+			return this;
+		}
+
 		System.IO.DirectoryInfo ContentFolder;
 		public Editor WithContent( System.IO.DirectoryInfo t ) { this.ContentFolder = t; return this; }
 		public Editor WithContent( string folderName ) { return WithContent( new System.IO.DirectoryInfo( folderName ) ); }
@@ -214,6 +232,18 @@ namespace Steamworks.Ugc
 					}
 				}
 
+				if ( AdditionalPreviewFiles != null )
+				{
+					foreach ( var file in AdditionalPreviewFiles )
+						SteamUGC.Internal.AddItemPreviewFile( handle, file.Item1, file.Item2 );
+				}
+
+				if ( RemovePreviewFiles != null )
+				{
+					foreach ( var i in RemovePreviewFiles )
+						SteamUGC.Internal.RemoveItemPreview( handle, (uint) i );
+				}
+				
 				result.Result = Steamworks.Result.Fail;
 
 				if ( ChangeLog == null )


### PR DESCRIPTION
Adds methods to expose [ISteamUGC.AddItemPreviewFile](https://partner.steamgames.com/doc/api/ISteamUGC#AddItemPreviewFile) and [ISteamUGC.RemoveItemPreview](https://partner.steamgames.com/doc/api/ISteamUGC#RemoveItemPreview). These let you upload multiple preview images for your workshop upload, without them you can only upload one.

Related: #47 