### PR TITLE
Add no-allocation controller retrieval + public SteamInput.Init method

### DIFF
--- a/Facepunch.Steamworks.Test/InputTest.cs
+++ b/Facepunch.Steamworks.Test/InputTest.cs
@@ -1,11 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Steamworks.Data;
 
 namespace Steamworks
 {
@@ -15,6 +11,20 @@ namespace Steamworks
 	[DeploymentItem( "controller_config/game_actions_252490.vdf" )]
     public class InputTest
 	{
+		[ClassInitialize]
+		public static void ClassInitialize( TestContext context )
+		{
+			const bool explicitlyCallEveryFrame = true;
+			bool initialized = SteamInput.Init( explicitlyCallEveryFrame );
+			Assert.IsTrue( initialized );
+		}
+
+		[TestInitialize]
+		public void Setup()
+		{
+			SteamInput.RunFrame();
+		}
+
 		[TestMethod]
         public void ControllerList()
         {
@@ -26,7 +36,55 @@ namespace Steamworks
 				var astate = controller.GetAnalogState( "Move" );
 			}
 		}
-	}
 
+		[TestMethod]
+		public void ControllerListNoAlloc()
+		{
+			List<Controller> controllers = new List<Controller>();
+			SteamInput.GetControllerNoAlloc( controllers );
+			foreach ( var controller in controllers )
+			{
+				Console.Write( $"Controller: {controller}" );
+
+				var dstate = controller.GetDigitalState( "fire" );
+				var astate = controller.GetAnalogState( "Move" );
+			}
+
+			CollectionAssert.AreEqual( SteamInput.Controllers.ToList(), controllers );
+		}
+
+		[TestMethod]
+		public void ControllerAllocates()
+		{
+			bool allocates = Allocates( () => _ = SteamInput.Controllers );
+			Assert.IsTrue( allocates , "Expected default SteamInput.Controllers to allocate");
+		}
+
+		[TestMethod]
+		public void ControllerListNoAllocDoesNotAllocate()
+		{
+			// Ensure list is big enough to fit all possible controllers
+			// so allocation of list isn't a concern
+			List<Controller> controllers = new List<Controller>( 1_000 );
+			bool allocates = Allocates( () => SteamInput.GetControllerNoAlloc( controllers ) );
+			Assert.IsFalse( allocates , 
+				"Expected new allocation-free SteamInput.GetControllerNoAlloc to not allocate");
+		}
+
+		// Best guess at allocation test, need NUnit's Is.Not.AllocatingGCMemory() if we want 
+		// something better
+		private static bool Allocates( Action action )
+		{
+			// Warm up JIT
+			action();
+
+			// Try our best to ensure GC doesn't kick in or around action execution
+			GC.Collect();
+			long before = GC.GetAllocatedBytesForCurrentThread();
+			action();
+			long after = GC.GetAllocatedBytesForCurrentThread();
+
+			return before < after;
+		}
+	}
 }
- 

--- a/Facepunch.Steamworks/SteamInput.cs
+++ b/Facepunch.Steamworks/SteamInput.cs
@@ -21,6 +21,14 @@ namespace Steamworks
 
 		internal const int STEAM_CONTROLLER_MAX_COUNT = 16;
 
+		/// <summary>
+		/// Must be called when starting use of the ISteamInput interface.
+		/// </summary>
+		public static bool Init( bool explicitlyCallRunFrame = false )
+		{
+			return Internal.Init( explicitlyCallRunFrame );
+		}
+
 
 		/// <summary>
 		/// You shouldn't really need to call this because it gets called by <see cref="SteamClient.RunCallbacks"/>
@@ -50,6 +58,21 @@ namespace Steamworks
 			}
 		}
 
+		/// <summary>
+		/// Gets a list of connected controllers, storing them in the provided list. The list will be cleared.
+		/// The controllers returned will be identical to the `Controllers` enumeration, except that no garbage
+		/// is generated.
+		/// </summary>
+		public static void GetControllerNoAlloc(List<Controller> controllers)
+		{
+			controllers.Clear();
+			var num = Internal.GetConnectedControllers( queryArray );
+
+			for ( int i = 0; i < num; i++ )
+			{
+				controllers.Add( new Controller( queryArray[i])  );
+			}
+		}
 
         /// <summary>
         /// Return an absolute path to the PNG image glyph for the provided digital action name. The current


### PR DESCRIPTION
# The Problem

Currently, controller retrieval through `SteamInput.Controllers` allocates memory every time it is called due to having to create the enumerator object to statefully walk through `yield return`. Most games will be running this code inside an `Update` loop, to retrieve current controller state and fire input events.

The general advice to pretty much all game developers is: "Don't allocate in Update". Doing so will generate huge amounts of garbage, causing the Garbage Collector to kick in over and over, which tanks FPS.

Unity has learned this lesson over the years and has started shipping allocation-free versions of its methods that used to return arrays. [See](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/Component.GetComponentsInChildren.html):

```csharp
// Allocates memory always
public T[] GetComponentsInChildren<T>();

// Doesn't allocate memory (assuming the results list doesn't need to be resized), 
// will populate the provided `results` list with found children
public void GetComponentsInChildren(List<T> results); 
```

# The Solution
I've implemented a simple alternative to the `SteamInput.Controllers` enumeration, which I've called `SteamInput.GetControllersNoAlloc`. The implementation is the same, except that it does not allocate an enumerator, leading to less garbage being generated, which results in an allocation-free method that can safely be called during `Update`

# Tests
I have simple tests around equivalence, as well as tests for allocation (existing) v no allocation (this approach) in a simplistic manner.

# Extra
In order to try to test this the best I could, I needed to add a fix for bug #512, which is a public `Init` method.