### PR TITLE
Add support for Steam beta branch management APIs

### DIFF
--- a/Facepunch.Steamworks/SteamApps.cs
+++ b/Facepunch.Steamworks/SteamApps.cs
@@ -162,6 +162,68 @@ namespace Steamworks
 		}
 
 		/// <summary>
+		/// Gets the total number of known app branches including the default "public" branch.
+		/// </summary>
+		/// <param name="availableCount">Returns the number of available beta branches.</param>
+		/// <param name="privateCount">Returns the number of private beta branches.</param>
+		/// <returns>The total number of beta branches.</returns>
+		public static int GetBetaCount( out int availableCount, out int privateCount )
+		{
+			availableCount = 0;
+			privateCount = 0;
+			return Internal.GetNumBetas( ref availableCount, ref privateCount );
+		}
+
+		/// <summary>
+		/// Gets detailed information about a specific beta branch by index.
+		/// </summary>
+		/// <param name="betaIndex">The index of the beta branch (0-based).</param>
+		/// <returns>Beta branch information, or null if the index is invalid.</returns>
+		public static BetaInformation? GetBetaInfo( int betaIndex )
+		{
+			uint flags = 0;
+			uint buildId = 0;
+			
+			if ( !Internal.GetBetaInfo( betaIndex, ref flags, ref buildId, out var name, out var description ) )
+				return null;
+
+			return new BetaInformation
+			{
+				Name = name,
+				Description = description,
+				BuildId = buildId,
+				Flags = (BetaBranchFlags)flags
+			};
+		}
+
+		/// <summary>
+		/// Gets information about all available beta branches.
+		/// </summary>
+		/// <returns>An enumerable of beta branch information.</returns>
+		public static IEnumerable<BetaInformation> GetBetaInformation()
+		{
+			int totalCount = GetBetaCount( out var availableCount, out var privateCount );
+			
+			for ( int i = 0; i < totalCount; i++ )
+			{
+				var betaInfo = GetBetaInfo( i );
+				if ( betaInfo.HasValue )
+					yield return betaInfo.Value;
+			}
+		}
+
+		/// <summary>
+		/// Selects the specified beta branch as active for this app. 
+		/// The game may need to restart so Steam can update to that branch.
+		/// </summary>
+		/// <param name="betaName">The name of the beta branch to activate. Use null or empty string to select the default "public" branch.</param>
+		/// <returns>True if the beta branch was successfully set as active.</returns>
+		public static bool SetActiveBeta( string betaName )
+		{
+			return Internal.SetActiveBeta( betaName ?? "" );
+		}
+
+		/// <summary>
 		/// Force verify game content on next launch.
 		/// <para>
 		/// If you detect the game is out-of-date (for example, by having the client detect a version mismatch with a server),

--- a/Facepunch.Steamworks/Structs/BetaInformation.cs
+++ b/Facepunch.Steamworks/Structs/BetaInformation.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+
+namespace Steamworks.Data
+{
+	/// <summary>
+	/// Provides information about a beta branch.
+	/// </summary>
+	public struct BetaInformation
+	{
+		/// <summary>
+		/// The name of the beta branch.
+		/// </summary>
+		public string Name { get; internal set; }
+
+		/// <summary>
+		/// The description of the beta branch.
+		/// </summary>
+		public string Description { get; internal set; }
+
+		/// <summary>
+		/// The build ID of the beta branch.
+		/// </summary>
+		public uint BuildId { get; internal set; }
+
+		/// <summary>
+		/// The flags indicating the status of the beta branch.
+		/// </summary>
+		internal BetaBranchFlags Flags { get; set; }
+
+		/// <summary>
+		/// Whether this is the default branch.
+		/// </summary>
+		public bool IsDefault => (Flags & BetaBranchFlags.Default) != 0;
+
+		/// <summary>
+		/// Whether this beta branch is available for selection.
+		/// </summary>
+		public bool IsAvailable => (Flags & BetaBranchFlags.Available) != 0;
+
+		/// <summary>
+		/// Whether this beta branch is private (requires password or invitation).
+		/// </summary>
+		public bool IsPrivate => (Flags & BetaBranchFlags.Private) != 0;
+
+		/// <summary>
+		/// Whether this beta branch is currently selected by the user.
+		/// </summary>
+		public bool IsSelected => (Flags & BetaBranchFlags.Selected) != 0;
+
+		/// <summary>
+		/// Whether this beta branch is currently installed.
+		/// </summary>
+		public bool IsInstalled => (Flags & BetaBranchFlags.Installed) != 0;
+	}
+}


### PR DESCRIPTION
Implements GetNumBetas, GetBetaInfo, and SetActiveBeta Steam APIs that were missing from the library. These APIs allow applications to query available beta branches and programmatically switch between them.

New APIs added:
- SteamApps.GetBetaCount() - Get total number of beta branches with breakdown of available/private counts
- SteamApps.GetBetaInfo() - Get detailed information about a specific beta branch by index
- SteamApps.GetBetaInformation() - Get enumerable of all available beta branches
- SteamApps.SetActiveBeta() - Set the active beta branch for the application

Also adds BetaInformation struct with convenient property accessors for beta branch flags (IsDefault, IsAvailable, IsPrivate, IsSelected, IsInstalled).

The low-level Steam API bindings were already generated, this change adds the high-level C# wrapper methods following existing code patterns in SteamApps.cs.