### PR TITLE
Fixed truncated session ticket array

### DIFF
--- a/Facepunch.Steamworks/SteamUser.cs
+++ b/Facepunch.Steamworks/SteamUser.cs
@@ -314,7 +314,7 @@ namespace Steamworks
 		/// </summary>
 		public static unsafe AuthTicket GetAuthSessionTicket( NetIdentity identity )
 		{
-			var data = Helpers.TakeBuffer( 1024 );
+			var data = Helpers.TakeBuffer( 2560 );
 
 			fixed ( byte* b = data )
 			{


### PR DESCRIPTION
## Summary

This PR fixes a bug where the session ticket array retrieved via `GetAuthSessionTicket` is truncated. Rather than `1024`, it seems like the max size retrieved for this session ticket array can be `2560` based on the C API docs in https://github.com/Facepunch/Facepunch.Steamworks/blob/aa87fe557fa0578b4361bf0f23848d64d0c94a79/Generator/steam_sdk/isteamuser.h#L432. 

This PR resolves that by increasing the size of the array used to match the C array max size, but I have not been able to test it as I haven't been able to build this solution on macOS. I've tested using the equivalent API in Steamworks.net which uses the right size and was able to verify that allows for a proper sign in using Unity Game Services (see issue https://github.com/Facepunch/Facepunch.Steamworks/issues/827).

Could someone build the solution and upload a zip of the published assemblies so I can test? I can try building myself on a Windows machine which may fare better, but it might take a bit.