### PR TITLE
Add support for additional workshop preview files

### DIFF
--- a/Facepunch.Steamworks/Structs/UgcEditor.cs
+++ b/Facepunch.Steamworks/Structs/UgcEditor.cs
@@ -69,6 +69,24 @@ namespace Steamworks.Ugc
 		string PreviewFile;
 		public Editor WithPreviewFile( string t ) { this.PreviewFile = t; return this; }
 
+		List<(string, ItemPreviewType)> AdditionalPreviewFiles;
+		
+		List<int> RemovePreviewFiles;
+
+		public Editor AddAdditionalPreviewFile( string f, ItemPreviewType t )
+		{
+			AdditionalPreviewFiles ??= new List<(string, ItemPreviewType)>();
+			AdditionalPreviewFiles.Add((f, t));
+			return this;
+		}
+		
+		public Editor RemoveAdditionalPreviewFile( int i )
+		{
+			RemovePreviewFiles ??= new List<int>();
+			RemovePreviewFiles.Add(i);
+			return this;
+		}
+
 		System.IO.DirectoryInfo ContentFolder;
 		public Editor WithContent( System.IO.DirectoryInfo t ) { this.ContentFolder = t; return this; }
 		public Editor WithContent( string folderName ) { return WithContent( new System.IO.DirectoryInfo( folderName ) ); }
@@ -214,6 +232,18 @@ namespace Steamworks.Ugc
 					}
 				}
 
+				if ( AdditionalPreviewFiles != null )
+				{
+					foreach ( var file in AdditionalPreviewFiles )
+						SteamUGC.Internal.AddItemPreviewFile( handle, file.Item1, file.Item2 );
+				}
+
+				if ( RemovePreviewFiles != null )
+				{
+					foreach ( var i in RemovePreviewFiles )
+						SteamUGC.Internal.RemoveItemPreview( handle, (uint) i );
+				}
+				
 				result.Result = Steamworks.Result.Fail;
 
 				if ( ChangeLog == null )

--- a/Facepunch.Steamworks/Structs/UgcEditor.cs
+++ b/Facepunch.Steamworks/Structs/UgcEditor.cs
@@ -69,17 +69,15 @@ namespace Steamworks.Ugc
 		string PreviewFile;
 		public Editor WithPreviewFile( string t ) { this.PreviewFile = t; return this; }
 
-		List<(string, ItemPreviewType)> AdditionalPreviewFiles;
-		
-		List<int> RemovePreviewFiles;
-
+		Dictionary<string, ItemPreviewType> AdditionalPreviewFiles;
 		public Editor AddAdditionalPreviewFile( string f, ItemPreviewType t )
 		{
-			AdditionalPreviewFiles ??= new List<(string, ItemPreviewType)>();
-			AdditionalPreviewFiles.Add((f, t));
+			AdditionalPreviewFiles ??= new Dictionary<string, ItemPreviewType>();
+			AdditionalPreviewFiles.Add(f, t);
 			return this;
 		}
 		
+		List<int> RemovePreviewFiles;
 		public Editor RemoveAdditionalPreviewFile( int i )
 		{
 			RemovePreviewFiles ??= new List<int>();
@@ -235,13 +233,13 @@ namespace Steamworks.Ugc
 				if ( AdditionalPreviewFiles != null )
 				{
 					foreach ( var file in AdditionalPreviewFiles )
-						SteamUGC.Internal.AddItemPreviewFile( handle, file.Item1, file.Item2 );
+						SteamUGC.Internal.AddItemPreviewFile( handle, file.Key, file.Value );
 				}
 
 				if ( RemovePreviewFiles != null )
 				{
-					foreach ( var i in RemovePreviewFiles )
-						SteamUGC.Internal.RemoveItemPreview( handle, (uint) i );
+					foreach ( var fileIndex in RemovePreviewFiles )
+						SteamUGC.Internal.RemoveItemPreview( handle, (uint) fileIndex );
 				}
 				
 				result.Result = Steamworks.Result.Fail;
@@ -249,7 +247,7 @@ namespace Steamworks.Ugc
 				if ( ChangeLog == null )
 					ChangeLog = "";
 
-			   var updating = SteamUGC.Internal.SubmitItemUpdate( handle, ChangeLog );
+			    var updating = SteamUGC.Internal.SubmitItemUpdate( handle, ChangeLog );
 
 				while ( !updating.IsCompleted )
 				{


### PR DESCRIPTION
Fixed Tuple import error, changed some formatting

Copied from #796 : "Adds methods to expose [ISteamUGC.AddItemPreviewFile](https://partner.steamgames.com/doc/api/ISteamUGC#AddItemPreviewFile) and [ISteamUGC.RemoveItemPreview](https://partner.steamgames.com/doc/api/ISteamUGC#RemoveItemPreview). These let you upload multiple preview images for your workshop upload, without them you can only upload one."
Thank you @nrgill28 !