### PR TITLE
Expose RemoteStorageLocalFileChange_t callback

### DIFF
--- a/Facepunch.Steamworks/SteamRemoteStorage.cs
+++ b/Facepunch.Steamworks/SteamRemoteStorage.cs
@@ -19,8 +19,20 @@ namespace Steamworks
 			SetInterface( server, new ISteamRemoteStorage( server ) );
 			if ( Interface.Self == IntPtr.Zero ) return false;
 
+			InstallEvents();
+
 			return true;
 		}
+
+		internal static void InstallEvents()
+		{
+			Dispatch.Install<RemoteStorageLocalFileChange_t>( x => OnLocalFileChange?.Invoke() );
+		}
+
+		/// <summary>
+		/// If a Steam app is flagged for supporting dynamic Steam Cloud sync, and a sync occurs, this callback will be posted to the app if any local files changed.
+		/// </summary>
+		public static event Action OnLocalFileChange;
 
 
 		/// <summary>


### PR DESCRIPTION
Added a public event for the RemoteStorageLocalFileChange_t callback. This is necessary for properly handling dynamic cloud sync. 
If the player suspends a game on steam deck, the save data is synced. Then if the player continues playing on a different device, syncs new save data, and later unsuspends the game on the steam deck, this callback will be posted so the game can respond to the new save data.