### PR TITLE
Nuget package targetting mulitple RIDs

### DIFF
--- a/Facepunch.Steamworks/Facepunch.Steamworks.csproj
+++ b/Facepunch.Steamworks/Facepunch.Steamworks.csproj
@@ -1,0 +1,71 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyName>Facepunch.Steamworks</AssemblyName>
+        <TargetFramework>net6.0</TargetFramework>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+        <RootNamespace>Steamworks</RootNamespace>
+
+        <RuntimeIdentifiers>win-x86;win-x64;linux-x86;linux-x64</RuntimeIdentifiers>
+
+        <!-- As far as I can tell, PLATFORM_WIN is not used -->
+        <DefineConstants Condition="'$(RuntimeIdentifier)' == 'win-x86'">$(DefineConstants);PLATFORM_WIN32</DefineConstants>
+        <DefineConstants Condition="'$(RuntimeIdentifier)' == 'win-x64'">$(DefineConstants);PLATFORM_WIN64</DefineConstants>
+        <DefineConstants Condition="'$(RuntimeIdentifier)' == 'linux-x86'">$(DefineConstants);PLATFORM_POSIX32</DefineConstants>
+        <DefineConstants Condition="'$(RuntimeIdentifier)' == 'linux-x64'">$(DefineConstants);PLATFORM_POSIX64</DefineConstants>
+        <DefineConstants Condition="'$(RuntimeIdentifier)' == 'osx-x64'">$(DefineConstants);PLATFORM_OSX64</DefineConstants>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <Authors>Garry Newman</Authors>
+        <PackageId>Facepunch.Steamworks.multiplatform</PackageId>
+        <PackageDescription>Steamworks implementation with an emphasis on making things easy. Multiplatform (not for Unity)</PackageDescription>
+        <PackageProjectUrl>https://github.com/Facepunch/Facepunch.Steamworks</PackageProjectUrl>
+        <PackageIcon>Facepunch.Steamworks.jpg</PackageIcon>
+        <PackageTags>facepunch;steam;steamworks;valve;godot</PackageTags>
+        <LangVersion>10</LangVersion>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <RepositoryUrl>https://github.com/Facepunch/Facepunch.Steamworks.git</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="Facepunch.Steamworks.jpg">
+            <Pack>true</Pack>
+            <PackagePath>/</PackagePath>
+        </None>
+        <None Include="..\UnityPlugin\redistributable_bin\steam_api.dll" Condition="'$(RuntimeIdentifier)' == 'win-x86'">
+            <Link>%(Filename)%(Extension)</Link>
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>content</PackagePath>
+        </None>
+        <None Include="..\UnityPlugin\redistributable_bin\win64\steam_api64.dll" Condition="'$(RuntimeIdentifier)' == 'win-x64'">
+            <Link>%(Filename)%(Extension)</Link>
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>content</PackagePath>
+        </None>
+        <None Include="..\UnityPlugin\redistributable_bin\linux32\libsteam_api.so" Condition="'$(RuntimeIdentifier)' == 'linux-x86'">
+            <Link>%(Filename)%(Extension)</Link>
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>content</PackagePath>
+        </None>
+        <None Include="..\UnityPlugin\redistributable_bin\linux64\libsteam_api.so" Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
+            <Link>%(Filename)%(Extension)</Link>
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>content</PackagePath>
+        </None>
+        <None Include="..\UnityPlugin\redistributable_bin\osx\libsteam_api.dynlib" Condition="'$(RuntimeIdentifier)' == 'osx-x64'">
+            <Link>%(Filename)%(Extension)</Link>
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>content</PackagePath>
+        </None>
+    </ItemGroup>
+
+    <Import Project="Facepunch.Steamworks.targets" />
+</Project>

--- a/Facepunch.Steamworks/Facepunch.Steamworks.multiplatform.nuspec
+++ b/Facepunch.Steamworks/Facepunch.Steamworks.multiplatform.nuspec
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>Facepunch.Steamworks.multiplatform</id>
+    <version>2.4.1-multiarch</version>
+    <authors>Garry Newman</authors>
+    <owners>Garry Newman</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/Facepunch/Facepunch.Steamworks</projectUrl>
+    <icon>Facepunch.Steamworks.jpg</icon>
+    <description>Steamworks implementation with an emphasis on making things easy. Multiplatform (not for Unity)</description>
+    <tags>facepunch;steam;steamworks;valve;godot</tags>
+    <repository type="git" url="https://github.com/Facepunch/Facepunch.Steamworks.git" />
+    <dependencies>
+      <group targetFramework="net6.0" />
+    </dependencies>
+  </metadata>
+  <files>
+      <file src="Facepunch.Steamworks.jpg" />
+      <file src="bin\Release\net6.0\win-x86\Facepunch.Steamworks.dll" target="ref\net6.0\" />
+
+      <file src="bin\Release\net6.0\win-x86\Facepunch.Steamworks.dll" target="runtimes\win-x86\lib\net6.0\" />
+      <file src="bin\Release\net6.0\win-x86\steam_api.dll" target="runtimes\win-x86\native\" />
+
+      <file src="bin\Release\net6.0\win-x64\Facepunch.Steamworks.dll" target="runtimes\win-x64\lib\net6.0\" />
+      <file src="bin\Release\net6.0\win-x64\steam_api64.dll" target="runtimes\win-x64\native\" />
+
+      <file src="bin\Release\net6.0\linux-x86\Facepunch.Steamworks.dll" target="runtimes\linux-x86\lib\net6.0\" />
+      <file src="bin\Release\net6.0\linux-x86\libsteam_api.so" target="runtimes\linux-x86\native\" />
+
+      <file src="bin\Release\net6.0\linux-x64\Facepunch.Steamworks.dll" target="runtimes\linux-x64\lib\net6.0\" />
+      <file src="bin\Release\net6.0\linux-x64\libsteam_api.so" target="runtimes\linux-x64\native\" />
+  </files>
+</package>

--- a/Facepunch.Steamworks/Utility/Platform.cs
+++ b/Facepunch.Steamworks/Utility/Platform.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Runtime.InteropServices;
-using System.Text;
+﻿using System.Runtime.InteropServices;
 
 namespace Steamworks
 {
@@ -16,9 +10,15 @@ namespace Steamworks
 #elif PLATFORM_WIN32
 		public const int StructPlatformPackSize = 8;
 		public const string LibraryName = "steam_api";
-#elif PLATFORM_POSIX
+#elif PLATFORM_POSIX64 || PLATFORM_POSIX32
 		public const int StructPlatformPackSize = 4;
 		public const string LibraryName = "libsteam_api";
+#elif  PLATFORM_OSX64
+		public const int StructPlatformPackSize = 8;
+		public const string LibraryName = "libsteam_api";
+#else
+		public const int StructPlatformPackSize = 8;
+		public const string LibraryName = "steam_api";
 #endif
 
 		public const CallingConvention CC = CallingConvention.Cdecl;

--- a/PackMultiarch.bat
+++ b/PackMultiarch.bat
@@ -1,0 +1,6 @@
+dotnet clean
+dotnet build Facepunch.Steamworks/Facepunch.Steamworks.csproj -r win-x86 -c Release
+dotnet build Facepunch.Steamworks/Facepunch.Steamworks.csproj -r win-x64 -c Release
+dotnet build Facepunch.Steamworks/Facepunch.Steamworks.csproj -r linux-x86 -c Release
+dotnet build Facepunch.Steamworks/Facepunch.Steamworks.csproj -r linux-x64 -c Release
+nuget pack Facepunch.Steamworks/Facepunch.Steamworks.multiplatform.nuspec


### PR DESCRIPTION
My use case is multiplatform builds with Godot, which uses the regular build system.

Added a project & nuspec to gather builds & native libs for various RIDs. Split PLATFORM_POSIX into 32/64, not really needed on the code side, so this bit could be reverted (but may be useful to keep).

Tested on win-x64 & linux-x64 for the subset of features used in Chess: Definitive Edition (rich presence, achievements, cross-platform networking).

Needs review & acceptance of the general approach.

Needs a decision on an appropriate package id.

Needs a rebase and version update.