### PR TITLE
Fix lobbies always being discoverable by everyone briefly after lobby creation

### DIFF
--- a/Facepunch.Steamworks/SteamMatchmaking.cs
+++ b/Facepunch.Steamworks/SteamMatchmaking.cs
@@ -152,7 +152,7 @@ namespace Steamworks
 		/// </summary>
 		public static async Task<Lobby?> CreateLobbyAsync( int maxMembers = 100 )
 		{
-			var lobby = await Internal.CreateLobby( LobbyType.Invisible, maxMembers );
+			var lobby = await Internal.CreateLobby( LobbyType.Private, maxMembers );
 			if ( !lobby.HasValue || lobby.Value.Result != Result.OK ) return null;
 
 			return new Lobby { Id = lobby.Value.SteamIDLobby };


### PR DESCRIPTION
I recently had an issue in my game where random people were able to join friends only lobbies uninvited.

This caused various issues, most notably someone made an automatic bot which would join any possible lobbies with a modded client to cause all sorts of issues, griefing random players' games.

The issue is, if you set the lobby type to invisible, it can still be seen by search queries, as is apparent in [Steamworks docs](https://partner.steamgames.com/doc/api/ISteamMatchmaking#ELobbyType):
`k_ELobbyTypeInvisible: Returned by search, but not visible to other friends.`

Even if you instantly change the lobby type after creation, it will still show up in search queries for a few seconds. This means that for any malicious party it is trivial to just keep spamming the search query and collect a list of all lobbies that have been created, and since friends only lobbies are joinable by anyone with the lobby id, this creates an issue.

After changing the lobby type to private on creation as per this commit, the issue was resolved.