### PR TITLE
InventoryResult: added GetItems(string[]) overload to fetch specific item properties

### DIFF
--- a/Facepunch.Steamworks/Structs/InventoryItem.cs
+++ b/Facepunch.Steamworks/Structs/InventoryItem.cs
@@ -116,6 +116,23 @@ namespace Steamworks
 			return props;
 		}
 
+		internal static Dictionary<string, string> GetProperties( SteamInventoryResult_t result, int index, string[] propertyNames )
+		{
+			// Only fetch the requested properties. This skips the "list all property names" call and avoids reading properties we don't care about
+			// Each property is a separate native call, so for large result sets it can't be super slow
+			var props = new Dictionary<string, string>( propertyNames.Length );
+
+			foreach ( var propertyName in propertyNames )
+			{
+				if ( SteamInventory.Internal.GetResultItemProperty( result, (uint)index, propertyName, out var strVal ) )
+				{
+					props.Add( propertyName, strVal );
+				}
+			}
+
+			return props;
+		}
+
 		/// <summary>
 		/// Will try to return the date that this item was aquired. You need to have for the items
 		/// with their properties for this to work.

--- a/Facepunch.Steamworks/Structs/InventoryResult.cs
+++ b/Facepunch.Steamworks/Structs/InventoryResult.cs
@@ -62,7 +62,36 @@ namespace Steamworks
 			}
 
 
-			return items;			
+			return items;
+		}
+
+		/// <summary>
+		/// Like <see cref="GetItems(bool)"/>, but only reads the named item properties instead of every property.
+		/// Is much cheaper for large result sets. Note this is still O(items x properties) native calls.
+		/// </summary>
+		public InventoryItem[] GetItems( string[] withProperties )
+		{
+			uint cnt = (uint) ItemCount;
+			if ( cnt <= 0 ) return null;
+
+			var pOutItemsArray = new SteamItemDetails_t[cnt];
+
+			if ( !SteamInventory.Internal.GetResultItems( _id, pOutItemsArray, ref cnt ) )
+				return null;
+
+			var items = new InventoryItem[cnt];
+
+			for( int i=0; i< cnt; i++ )
+			{
+				var item = InventoryItem.From( pOutItemsArray[i] );
+
+				if ( withProperties != null && withProperties.Length > 0 )
+					item._properties = InventoryItem.GetProperties( _id, i, withProperties );
+
+				items[i] = item;
+			}
+
+			return items;
 		}
 
 		public void Dispose()


### PR DESCRIPTION
Adds an overload in InventoryResult to let us fetch specific item properties of an item. Fetching all properties is slow, it's causing problems in Rust for players with large inventories.