### PR TITLE
Initialize and reset SteamInput sessions correctly

### DIFF
--- a/Facepunch.Steamworks/SteamInput.cs
+++ b/Facepunch.Steamworks/SteamInput.cs
@@ -16,7 +16,23 @@ namespace Steamworks
 			SetInterface( server, new ISteamInput( server ) );
 			if ( Interface.Self == IntPtr.Zero ) return false;
 
-			return true;
+			// ISteamInput requires an explicit Init before any other call - without it
+			// GetConnectedControllers always returns zero controllers.
+			return Internal.Init( false );
+		}
+
+		internal override void DestroyInterface( bool server )
+		{
+			if ( Internal != null && Internal.IsValid )
+				Internal.Shutdown();
+
+			// Action and action-set handles are only valid for the lifetime of the input
+			// session - keeping them across a Shutdown/Init cycle would serve stale handles
+			DigitalHandles.Clear();
+			AnalogHandles.Clear();
+			ActionSets.Clear();
+
+			base.DestroyInterface( server );
 		}
 
 		internal const int STEAM_CONTROLLER_MAX_COUNT = 16;
@@ -48,6 +64,23 @@ namespace Steamworks
 					yield return new Controller( queryArray[i] );
 				}
 			}
+		}
+
+		/// <summary>
+		/// Fills the buffer with connected controllers and returns the count. Identical
+		/// results to <see cref="Controllers"/> but doesn't allocate, for per-frame polling.
+		/// </summary>
+		public static int GetControllers( Controller[] buffer )
+		{
+			var num = Internal.GetConnectedControllers( queryArray );
+			if ( num > buffer.Length ) num = buffer.Length;
+
+			for ( int i = 0; i < num; i++ )
+			{
+				buffer[i] = new Controller( queryArray[i] );
+			}
+
+			return num;
 		}
 
 


### PR DESCRIPTION
`ISteamInput` requires an explicit `Init()` before any other call — without it
`GetConnectedControllers` always returns zero, so `SteamInput.Controllers` has always
been empty for every consumer.

This initializes the interface in `InitializeInterface` (so Steam Input just works after
`SteamClient.Init`, like every other interface) and shuts it down in `DestroyInterface`,
also clearing the cached action/action-set handles which would otherwise go stale across
a Shutdown/Init cycle. Also adds `GetControllers(Controller[])` as a no-alloc alternative
to the `Controllers` iterator for per-frame polling.

Fixes #512, addresses #757 / #758. Alternative to #805 / #812 — those expose
`Init`/`Shutdown` for callers to remember to call; this fixes the interface contract
itself so no caller can hit the empty-controllers trap. (Credit to #812 for the no-alloc
controller idea.)